### PR TITLE
 Add volume context and parameters validation to ValidateVolumeCapabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/container-storage-interface/spec v1.1.0
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/golang/mock v1.2.0
-	github.com/kubernetes-csi/csi-test v2.0.1+incompatible
+	github.com/kubernetes-csi/csi-test v2.1.0+incompatible
 	github.com/mattn/goveralls v0.0.2 // indirect
 	github.com/onsi/ginkgo v1.7.0
 	github.com/onsi/gomega v1.4.3

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,10 @@ module github.com/kubernetes-sigs/aws-fsx-csi-driver
 
 require (
 	github.com/aws/aws-sdk-go v1.16.36
-	github.com/container-storage-interface/spec v0.3.0
+	github.com/container-storage-interface/spec v1.1.0
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/golang/mock v1.2.0
-	github.com/kubernetes-csi/csi-test v0.3.0-2
+	github.com/kubernetes-csi/csi-test v2.0.1+incompatible
 	github.com/mattn/goveralls v0.0.2 // indirect
 	github.com/onsi/ginkgo v1.7.0
 	github.com/onsi/gomega v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,11 @@ github.com/aws/aws-sdk-go v1.16.36/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/container-storage-interface/spec v0.3.0 h1:ALxSqFjptj8R5rL+cdyAbwbaLHHXDL5pmp1qIh1b+38=
 github.com/container-storage-interface/spec v0.3.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
+github.com/container-storage-interface/spec v1.1.0 h1:qPsTqtR1VUPvMPeK0UnCZMtXaKGyyLPG8gj/wG6VqMs=
+github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -22,6 +25,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kubernetes-csi/csi-test v0.3.0-2 h1:RsVmFc3AlpjQdyfMKiphvd8igXwOI7lQgWo+kJAh49c=
 github.com/kubernetes-csi/csi-test v0.3.0-2/go.mod h1:YxJ4UiuPWIhMBkxUKY5c267DyA0uDZ/MtAimhx/2TA0=
+github.com/kubernetes-csi/csi-test v2.0.1+incompatible h1:I1vqMmF42KywPatkdP2PMx9u/jeDPTdV/rWjABrH/tg=
+github.com/kubernetes-csi/csi-test v2.0.1+incompatible/go.mod h1:YxJ4UiuPWIhMBkxUKY5c267DyA0uDZ/MtAimhx/2TA0=
 github.com/mattn/goveralls v0.0.2 h1:7eJB6EqsPhRVxvwEXGnqdO2sJI0PTsrWoTMXEk9/OQc=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -37,6 +42,7 @@ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9+7a3s8RBNOZ3eYZzJA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e h1:o3PsSEY8E4eXWkXrIP9YJALUkVZqzHJT5DOasTyn8Vs=

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kubernetes-csi/csi-test v0.3.0-2 h1:RsVmFc3AlpjQdyfMKiphvd8igXwOI7lQgWo+kJAh49c=
 github.com/kubernetes-csi/csi-test v0.3.0-2/go.mod h1:YxJ4UiuPWIhMBkxUKY5c267DyA0uDZ/MtAimhx/2TA0=
-github.com/kubernetes-csi/csi-test v2.0.1+incompatible h1:I1vqMmF42KywPatkdP2PMx9u/jeDPTdV/rWjABrH/tg=
-github.com/kubernetes-csi/csi-test v2.0.1+incompatible/go.mod h1:YxJ4UiuPWIhMBkxUKY5c267DyA0uDZ/MtAimhx/2TA0=
+github.com/kubernetes-csi/csi-test v2.1.0+incompatible h1:tAwEHWnkd5jK1zgkTrYZogbG1xoyaFBWEED3vuB8iAI=
+github.com/kubernetes-csi/csi-test v2.1.0+incompatible/go.mod h1:YxJ4UiuPWIhMBkxUKY5c267DyA0uDZ/MtAimhx/2TA0=
 github.com/mattn/goveralls v0.0.2 h1:7eJB6EqsPhRVxvwEXGnqdO2sJI0PTsrWoTMXEk9/OQc=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"testing"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-sigs/aws-fsx-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/aws-fsx-csi-driver/pkg/driver/mocks"
@@ -90,15 +90,15 @@ func TestCreateVolume(t *testing.T) {
 					t.Fatal("resp.Volume is nil")
 				}
 
-				if resp.Volume.Id != fileSystemId {
-					t.Fatalf("VolumeId mismatches. actual: %v expected: %v", resp.Volume.Id, fileSystemId)
+				if resp.Volume.VolumeId != fileSystemId {
+					t.Fatalf("VolumeId mismatches. actual: %v expected: %v", resp.Volume.VolumeId, fileSystemId)
 				}
 
 				if resp.Volume.CapacityBytes == 0 {
 					t.Fatalf("resp.Volume.CapacityGiB is zero")
 				}
 
-				name, exists := resp.Volume.Attributes["dnsname"]
+				name, exists := resp.Volume.VolumeContext["dnsname"]
 				if !exists {
 					t.Fatal("dnsname is missing")
 				}
@@ -384,7 +384,7 @@ func TestValidateVolumeCapabilities(t *testing.T) {
 				if err != nil {
 					t.Fatalf("ControllerGetCapabilities is failed: %v", err)
 				}
-				if !resp.Supported {
+				if resp.Confirmed == nil {
 					t.Fatal("capability is not supported")
 				}
 				mockCtl.Finish()

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"net"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-sigs/aws-fsx-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/aws-fsx-csi-driver/pkg/util"
 	"google.golang.org/grpc"

--- a/pkg/driver/identity.go
+++ b/pkg/driver/identity.go
@@ -19,7 +19,7 @@ package driver
 import (
 	"context"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 )
 
 func (d *Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog"
@@ -47,8 +47,8 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
 	}
 
-	attributes := req.GetVolumeAttributes()
-	dnsname := attributes["dnsname"]
+	context := req.GetVolumeContext()
+	dnsname := context["dnsname"]
 	if len(dnsname) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "dnsname is not provided")
 	}
@@ -109,6 +109,14 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }
 
+func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func (d *Driver) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "")
+}
+
 func (d *Driver) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
 	klog.V(4).Infof("NodeGetCapabilities: called with args %+v", req)
 	var caps []*csi.NodeServiceCapability
@@ -129,13 +137,6 @@ func (d *Driver) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (
 	klog.V(4).Infof("NodeGetInfo: called with args %+v", req)
 
 	return &csi.NodeGetInfoResponse{
-		NodeId: d.nodeID,
-	}, nil
-}
-
-func (d *Driver) NodeGetId(ctx context.Context, req *csi.NodeGetIdRequest) (*csi.NodeGetIdResponse, error) {
-	klog.V(4).Infof("NodeGetId: called with args %+v", req)
-	return &csi.NodeGetIdResponse{
 		NodeId: d.nodeID,
 	}, nil
 }

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"testing"
 
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-sigs/aws-fsx-csi-driver/pkg/driver/mocks"
 )
@@ -62,7 +62,7 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId: "volumeId",
-					VolumeAttributes: map[string]string{
+					VolumeContext: map[string]string{
 						"dnsname": dnsname,
 					},
 					VolumeCapability: stdVolCap,
@@ -93,7 +93,7 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId:         "volumeId",
-					VolumeAttributes: map[string]string{},
+					VolumeContext:    map[string]string{},
 					VolumeCapability: stdVolCap,
 					TargetPath:       targetPath,
 				}
@@ -120,7 +120,7 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId: "volumeId",
-					VolumeAttributes: map[string]string{
+					VolumeContext: map[string]string{
 						"dnsname": dnsname,
 					},
 					VolumeCapability: stdVolCap,
@@ -148,7 +148,7 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId: "volumeId",
-					VolumeAttributes: map[string]string{
+					VolumeContext: map[string]string{
 						"dnsname": dnsname,
 					},
 					TargetPath: targetPath,
@@ -176,7 +176,7 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId: "volumeId",
-					VolumeAttributes: map[string]string{
+					VolumeContext: map[string]string{
 						"dnsname": dnsname,
 					},
 					VolumeCapability: &csi.VolumeCapability{
@@ -212,7 +212,7 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId: "volumeId",
-					VolumeAttributes: map[string]string{
+					VolumeContext: map[string]string{
 						"dnsname": dnsname,
 					},
 					VolumeCapability: stdVolCap,
@@ -244,7 +244,7 @@ func TestNodePublishVolume(t *testing.T) {
 				ctx := context.Background()
 				req := &csi.NodePublishVolumeRequest{
 					VolumeId: "volumeId",
-					VolumeAttributes: map[string]string{
+					VolumeContext: map[string]string{
 						"dnsname": dnsname,
 					},
 					VolumeCapability: stdVolCap,

--- a/tests/sanity/sanity_test.go
+++ b/tests/sanity/sanity_test.go
@@ -53,6 +53,7 @@ var _ = AfterSuite(func() {
 })
 
 var _ = Describe("AWS FSx for Lustre CSI Driver", func() {
+	_ = os.MkdirAll("/tmp/csi", os.ModePerm)
 	config := &sanity.Config{
 		Address:        endpoint,
 		TargetPath:     mountPath,


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** bug fix

**What is this PR about? / Why do we need it?** CSI 1.0 changed ValidateVolumeCapabilities, now it should return all the fields it has validated instead of just `Supported`.  So, add volume context and parameters validation to the function just like how there is already volume capabilities validation

This is a follow-up to https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/69 , https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/69 should be reviewed first
**What testing is done?** `make test` passes
