### PR TITLE
Added flag for version information output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+PKG=github.com/kubernetes-sigs/aws-fsx-csi-driver
 IMAGE=amazon/aws-fsx-csi-driver
 VERSION=0.1.0
+GIT_COMMIT?=$(shell git rev-parse HEAD)
+BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE}"
 
 .PHONY: aws-fsx-csi-driver
 aws-fsx-csi-driver:
 	mkdir -p bin
-	CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/kubernetes-sigs/aws-fsx-csi-driver/pkg/driver.vendorVersion=${VERSION}" -o bin/aws-fsx-csi-driver ./cmd/
+	CGO_ENABLED=0 GOOS=linux go build -ldflags ${LDFLAGS} -o bin/aws-fsx-csi-driver ./cmd/
 
 .PHONY: test
 test:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,15 +18,29 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"os"
 
 	"github.com/kubernetes-sigs/aws-fsx-csi-driver/pkg/driver"
 	"k8s.io/klog"
 )
 
 func main() {
-	var endpoint = flag.String("endpoint", "unix://tmp/csi.sock", "CSI Endpoint")
+	var (
+		endpoint = flag.String("endpoint", "unix://tmp/csi.sock", "CSI Endpoint")
+		version  = flag.Bool("version", false, "Print the version and exit")
+	)
 	klog.InitFlags(nil)
 	flag.Parse()
+
+	if *version {
+		info, err := driver.GetVersionJSON()
+		if err != nil {
+			klog.Fatalln(err)
+		}
+		fmt.Println(info)
+		os.Exit(0)
+	}
 
 	drv := driver.NewDriver(*endpoint)
 	if err := drv.Run(); err != nil {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -33,10 +33,6 @@ const (
 )
 
 var (
-	vendorVersion = "0.1.0"
-)
-
-var (
 	volumeCaps = []csi.VolumeCapability_AccessMode{
 		{
 			Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,

--- a/pkg/driver/identity.go
+++ b/pkg/driver/identity.go
@@ -25,7 +25,7 @@ import (
 func (d *Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 	resp := &csi.GetPluginInfoResponse{
 		Name:          driverName,
-		VendorVersion: vendorVersion,
+		VendorVersion: driverVersion,
 	}
 
 	return resp, nil

--- a/pkg/driver/version.go
+++ b/pkg/driver/version.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+)
+
+var (
+	driverVersion string
+	gitCommit     string
+	buildDate     string
+)
+
+type VersionInfo struct {
+	DriverVersion string `json:"driverVersion"`
+	GitCommit     string `json:"gitCommit"`
+	BuildDate     string `json:"buildDate"`
+	GoVersion     string `json:"goVersion"`
+	Compiler      string `json:"compiler"`
+	Platform      string `json:"platform"`
+}
+
+func GetVersion() VersionInfo {
+	return VersionInfo{
+		DriverVersion: driverVersion,
+		GitCommit:     gitCommit,
+		BuildDate:     buildDate,
+		GoVersion:     runtime.Version(),
+		Compiler:      runtime.Compiler,
+		Platform:      fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}
+func GetVersionJSON() (string, error) {
+	info := GetVersion()
+	marshalled, err := json.MarshalIndent(&info, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(marshalled), nil
+}

--- a/pkg/driver/version_test.go
+++ b/pkg/driver/version_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func TestGetVersion(t *testing.T) {
+	version := GetVersion()
+
+	expected := VersionInfo{
+		DriverVersion: "",
+		GitCommit:     "",
+		BuildDate:     "",
+		GoVersion:     runtime.Version(),
+		Compiler:      runtime.Compiler,
+		Platform:      fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+
+	if !reflect.DeepEqual(version, expected) {
+		t.Fatalf("structs not equal\ngot:\n%+v\nexpected: \n%+v", version, expected)
+	}
+}
+func TestGetVersionJSON(t *testing.T) {
+	version, err := GetVersionJSON()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := fmt.Sprintf(`{
+  "driverVersion": "",
+  "gitCommit": "",
+  "buildDate": "",
+  "goVersion": "%s",
+  "compiler": "%s",
+  "platform": "%s"
+}`, runtime.Version(), runtime.Compiler, fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH))
+
+	if version != expected {
+		t.Fatalf("json not equal\ngot:\n%s\nexpected:\n%s", version, expected)
+	}
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** new feature

**What is this PR about? / Why do we need it?** fixes https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/27 to add --version flag. I simply copied https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/44 so it should behave exactly the same.

**What testing is done?** make test passes. Output looks like so: {
  "driverVersion": "0.1.0",
  "gitCommit": "e39f6cfa62bb39bf4c3d729b9b1b58003eed1494",
  "buildDate": "2019-07-24T20:55:18Z",
  "goVersion": "go1.11.4",
  "compiler": "gc",
  "platform": "linux/amd64"
}
