### PR TITLE
Implement mount options support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,8 @@ Following sections are Kubernetes specific. If you are Kubernetes user, use foll
 
 ### Features
 * Static provisioning - FSx for Lustre file system needs to be created manually first, then it could be mounted inside container as a volume using the Driver.
-* Dynamic provisioning - uses persistence volume claim (PVC) to let the Kuberenetes to create the FSx for Lustre filesystem for you and consumes the volume from inside container.
+* Dynamic provisioning - uses persistent volume claim (PVC) to let the Kuberenetes to create the FSx for Lustre filesystem for you and consumes the volume from inside container.
+* Mount options - mount options can be specified in persistent volume (PV) to define how the volume should be mounted.
 
 ### Installation
 #### Set up driver permission

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ Following sections are Kubernetes specific. If you are Kubernetes user, use foll
 ### Features
 * Static provisioning - FSx for Lustre file system needs to be created manually first, then it could be mounted inside container as a volume using the Driver.
 * Dynamic provisioning - uses persistent volume claim (PVC) to let the Kuberenetes to create the FSx for Lustre filesystem for you and consumes the volume from inside container.
-* Mount options - mount options can be specified in persistent volume (PV) to define how the volume should be mounted.
+* Mount options - mount options can be specified in storageclass to define how the volume should be mounted.
 
 ### Installation
 #### Set up driver permission

--- a/examples/kubernetes/dynamic_provisioning/specs/storageclass.yaml
+++ b/examples/kubernetes/dynamic_provisioning/specs/storageclass.yaml
@@ -6,3 +6,5 @@ provisioner: fsx.csi.aws.com
 parameters:
   subnetId: subnet-056da83524edbe641
   securityGroupIds: sg-086f61ea73388fb6b
+mountOptions:
+  - flock

--- a/examples/kubernetes/dynamic_provisioning_s3/specs/storageclass.yaml
+++ b/examples/kubernetes/dynamic_provisioning_s3/specs/storageclass.yaml
@@ -8,3 +8,5 @@ parameters:
   securityGroupIds: sg-086f61ea73388fb6b
   s3ImportPath: s3://ml-training-data-000
   s3ExportPath: s3://ml-training-data-000/export
+mountOptions:
+  - flock

--- a/examples/kubernetes/multiple_pods/specs/storageclass.yaml
+++ b/examples/kubernetes/multiple_pods/specs/storageclass.yaml
@@ -6,3 +6,5 @@ provisioner: fsx.csi.aws.com
 parameters:
   subnetId: subnet-056da83524edbe641
   securityGroupIds: sg-086f61ea73388fb6b
+mountOptions:
+  - flock

--- a/examples/kubernetes/static_provisioning/specs/storageclass.yaml
+++ b/examples/kubernetes/static_provisioning/specs/storageclass.yaml
@@ -3,3 +3,5 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: fsx-sc
 provisioner: fsx.csi.aws.com
+mountOptions:
+  - flock

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -80,6 +80,80 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "success: normal with read only mount",
+			testFunc: func(t *testing.T) {
+				mockCtrl := gomock.NewController(t)
+				mockMounter := mocks.NewMockInterface(mockCtrl)
+				driver := &Driver{
+					endpoint: endpoint,
+					nodeID:   nodeID,
+					mounter:  mockMounter,
+				}
+				source := dnsname + "@tcp:/fsx"
+
+				ctx := context.Background()
+				req := &csi.NodePublishVolumeRequest{
+					VolumeId: "volumeId",
+					VolumeAttributes: map[string]string{
+						"dnsname": dnsname,
+					},
+					VolumeCapability: stdVolCap,
+					TargetPath:       targetPath,
+					Readonly:         true,
+				}
+
+				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
+				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq("lustre"), gomock.Eq([]string{"ro"})).Return(nil)
+				_, err := driver.NodePublishVolume(ctx, req)
+				if err != nil {
+					t.Fatalf("NodePublishVolume is failed: %v", err)
+				}
+
+				mockCtrl.Finish()
+			},
+		},
+		{
+			name: "success: normal with flock mount options",
+			testFunc: func(t *testing.T) {
+				mockCtrl := gomock.NewController(t)
+				mockMounter := mocks.NewMockInterface(mockCtrl)
+				driver := &Driver{
+					endpoint: endpoint,
+					nodeID:   nodeID,
+					mounter:  mockMounter,
+				}
+				source := dnsname + "@tcp:/fsx"
+
+				ctx := context.Background()
+				req := &csi.NodePublishVolumeRequest{
+					VolumeId: "volumeId",
+					VolumeAttributes: map[string]string{
+						"dnsname": dnsname,
+					},
+					VolumeCapability: &csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{
+								MountFlags: []string{"flock"},
+							},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+						},
+					},
+					TargetPath: targetPath,
+				}
+
+				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
+				mockMounter.EXPECT().Mount(gomock.Eq(source), gomock.Eq(targetPath), gomock.Eq("lustre"), gomock.Eq([]string{"flock"})).Return(nil)
+				_, err := driver.NodePublishVolume(ctx, req)
+				if err != nil {
+					t.Fatalf("NodePublishVolume is failed: %v", err)
+				}
+
+				mockCtrl.Finish()
+			},
+		},
+		{
 			name: "fail: missing dns name",
 			testFunc: func(t *testing.T) {
 				mockCtrl := gomock.NewController(t)


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** new feature

**What is this PR about? / Why do we need it?** fix https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/65 and fix https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/30. Include the flock option in our example StorageClasses because according to http://wiki.lustre.org/Mounting_a_Lustre_File_System_on_Client_Nodes it's enabled by default and has no performance impact.

**What testing is done?** make test passes. ~will do an actual test with one of the examples and update.~ done, works
