### PR TITLE
Add support for 1200 GiB and 2400 GiB filesystems

### DIFF
--- a/examples/kubernetes/dynamic_provisioning/README.md
+++ b/examples/kubernetes/dynamic_provisioning/README.md
@@ -28,9 +28,9 @@ spec:
   storageClassName: fsx-sc
   resources:
     requests:
-      storage: 3600Gi
+      storage: 1200Gi
 ```
-Update `spec.resource.requests.storage` with the storage capacity to request. The storage capacity value will be rounded up multiplication of 3600GiB.
+Update `spec.resource.requests.storage` with the storage capacity to request. The storage capacity value will be rounded up to 1200 GiB, 2400 GiB, or a multiple of 3600 GiB.
 
 ### Deploy the Application
 Create PVC, storageclass and the pod that consumes the PV:

--- a/examples/kubernetes/dynamic_provisioning/specs/claim.yaml
+++ b/examples/kubernetes/dynamic_provisioning/specs/claim.yaml
@@ -8,4 +8,4 @@ spec:
   storageClassName: fsx-sc
   resources:
     requests:
-      storage: 3600Gi
+      storage: 1200Gi

--- a/examples/kubernetes/dynamic_provisioning_s3/README.md
+++ b/examples/kubernetes/dynamic_provisioning_s3/README.md
@@ -38,9 +38,9 @@ spec:
   storageClassName: fsx-sc
   resources:
     requests:
-      storage: 3600Gi
+      storage: 1200Gi
 ```
-Update `spec.resource.requests.storage` with the storage capacity to request. The storage capacity value will be rounded up to 1200 GiB, 2400 GiB, or amultiple of 3600 GiB.
+Update `spec.resource.requests.storage` with the storage capacity to request. The storage capacity value will be rounded up to 1200 GiB, 2400 GiB, or a multiple of 3600 GiB.
 
 ### Deploy the Application
 Create PVC, storageclass and the pod that consumes the PV:

--- a/examples/kubernetes/dynamic_provisioning_s3/README.md
+++ b/examples/kubernetes/dynamic_provisioning_s3/README.md
@@ -40,7 +40,7 @@ spec:
     requests:
       storage: 3600Gi
 ```
-Update `spec.resource.requests.storage` with the storage capacity to request. The storage capacity value will be rounded up multiplication of 3600GiB.
+Update `spec.resource.requests.storage` with the storage capacity to request. The storage capacity value will be rounded up to 1200 GiB, 2400 GiB, or amultiple of 3600 GiB.
 
 ### Deploy the Application
 Create PVC, storageclass and the pod that consumes the PV:

--- a/examples/kubernetes/dynamic_provisioning_s3/specs/claim.yaml
+++ b/examples/kubernetes/dynamic_provisioning_s3/specs/claim.yaml
@@ -8,4 +8,4 @@ spec:
   storageClassName: fsx-sc
   resources:
     requests:
-      storage: 3600Gi
+      storage: 1200Gi

--- a/examples/kubernetes/multiple_pods/specs/claim.yaml
+++ b/examples/kubernetes/multiple_pods/specs/claim.yaml
@@ -8,4 +8,4 @@ spec:
   storageClassName: fsx-sc
   resources:
     requests:
-      storage: 3600Gi
+      storage: 1200Gi

--- a/examples/kubernetes/static_provisioning/README.md
+++ b/examples/kubernetes/static_provisioning/README.md
@@ -9,7 +9,7 @@ metadata:
   name: fsx-pv
 spec:
   capacity:
-    storage: 3600Gi
+    storage: 1200Gi
   volumeMode: Filesystem
   accessModes:
     - ReadWriteMany

--- a/examples/kubernetes/static_provisioning/specs/claim.yaml
+++ b/examples/kubernetes/static_provisioning/specs/claim.yaml
@@ -8,4 +8,4 @@ spec:
   storageClassName: fsx-sc
   resources:
     requests:
-      storage: 3600Gi
+      storage: 1200Gi

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -35,7 +35,7 @@ import (
 const (
 	// DefaultVolumeSize represents the default size used
 	// this is the minimum FSx for Lustre FS size
-	DefaultVolumeSize = 3600
+	DefaultVolumeSize = 1200
 )
 
 // Tags

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -31,7 +31,7 @@ func TestCreateFileSystem(t *testing.T) {
 	var (
 		volumeName             = "volumeName"
 		fileSystemId           = "fs-1234"
-		volumeSizeGiB    int64 = 3600
+		volumeSizeGiB    int64 = 1200
 		subnetId               = "subnet-056da83524edbe641"
 		securityGroupIds       = []string{"sg-086f61ea73388fb6b", "sg-0145e55e976000c9e"}
 		dnsname                = "test.fsx.us-west-2.amazoawd.com"
@@ -322,7 +322,7 @@ func TestDeleteFileSystem(t *testing.T) {
 func TestDescribeFileSystem(t *testing.T) {
 	var (
 		fileSystemId        = "fs-1234"
-		volumeSizeGiB int64 = 3600
+		volumeSizeGiB int64 = 1200
 		dnsname             = "test.fsx.us-west-2.amazoawd.com"
 		s3ImportPath        = "s3://fsx-s3-data-repository"
 		s3ExportPath        = "s3://fsx-s3-data-repository/export"

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -58,7 +58,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	if capRange == nil {
 		volumeSizeGiB = cloud.DefaultVolumeSize
 	} else {
-		volumeSizeGiB = util.RoundUp3600GiB(capRange.GetRequiredBytes())
+		volumeSizeGiB = util.RoundUpVolumeSize(capRange.GetRequiredBytes())
 	}
 
 	volumeParams := req.GetParameters()

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -33,7 +33,7 @@ func TestCreateVolume(t *testing.T) {
 		endpoint               = "endpoint"
 		volumeName             = "volumeName"
 		fileSystemId           = "fs-1234"
-		volumeSizeGiB    int64 = 3600
+		volumeSizeGiB    int64 = 1200
 		subnetId               = "subnet-056da83524edbe641"
 		securityGroupIds       = "sg-086f61ea73388fb6b,sg-0145e55e976000c9e"
 		dnsname                = "test.fsx.us-west-2.amazoawd.com"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -29,10 +29,15 @@ const (
 	GiB = 1024 * 1024 * 1024
 )
 
-// RoundUp3600GiB rounds up the volume size in bytes upto
-// multiplications of 3600 GiB in the unit of GiB
-func RoundUp3600GiB(volumeSizeBytes int64) int64 {
-	return roundUpSize(volumeSizeBytes, 3600*GiB) * 3600
+// RoundUpVolumeSize rounds up the volume size in bytes upto
+// 1200 GiB, 2400 GiB, or multiplications of 3600 GiB in the
+// unit of GiB
+func RoundUpVolumeSize(volumeSizeBytes int64) int64 {
+	if volumeSizeBytes < 3600*GiB {
+		return roundUpSize(volumeSizeBytes, 1200*GiB) * 1200
+	} else {
+		return roundUpSize(volumeSizeBytes, 3600*GiB) * 3600
+	}
 }
 
 // GiBToBytes converts GiB to Bytes

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -29,7 +29,7 @@ func TestGiBToBytes(t *testing.T) {
 	}
 }
 
-func TestRoundUp3600GiB(t *testing.T) {
+func TestRoundUpVolumeSize(t *testing.T) {
 	testCases := []struct {
 		name        string
 		sizeInBytes int64
@@ -38,16 +38,26 @@ func TestRoundUp3600GiB(t *testing.T) {
 		{
 			name:        "Roundup 1 byte",
 			sizeInBytes: 1,
-			expected:    3600,
+			expected:    1200,
 		},
 		{
 			name:        "Roundup 1 Gib",
 			sizeInBytes: 1 * GiB,
-			expected:    3600,
+			expected:    1200,
+		},
+		{
+			name:        "Roundup 1000 Gib",
+			sizeInBytes: 1000 * GiB,
+			expected:    1200,
 		},
 		{
 			name:        "Roundup 2000 Gib",
 			sizeInBytes: 2000 * GiB,
+			expected:    2400,
+		},
+		{
+			name:        "Roundup 3000 Gib",
+			sizeInBytes: 3000 * GiB,
 			expected:    3600,
 		},
 		{
@@ -64,9 +74,9 @@ func TestRoundUp3600GiB(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := RoundUp3600GiB(tc.sizeInBytes)
+			actual := RoundUpVolumeSize(tc.sizeInBytes)
 			if actual != tc.expected {
-				t.Fatalf("RoundUp3600GiB got wrong result. actual: %d, expected: %d", actual, tc.expected)
+				t.Fatalf("RoundUpVolumeSize got wrong result. actual: %d, expected: %d", actual, tc.expected)
 			}
 		})
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixes #97 

**What is this PR about? / Why do we need it?**
This creates feature parity for FSx for Lustre filesystems per [Amazon FSx for Lustre Reduces Minimum File System Size to 1.2 TBs](https://aws.amazon.com/about-aws/whats-new/2019/09/amazon-fsx-lustre-reduces-minimum-file-system-size/). FSx for Lustre filesystems  now allow sizes of 1,200 GiB and 2,400 GiB in addition to increments of 3,600 GiB.

**What testing is done?** 
None yet. Will defer to CI.