### PR TITLE
Fix paths to dynamic_provisioning_s3 manifests

### DIFF
--- a/examples/kubernetes/dynamic_provisioning_s3/README.md
+++ b/examples/kubernetes/dynamic_provisioning_s3/README.md
@@ -45,9 +45,9 @@ Update `spec.resource.requests.storage` with the storage capacity to request. Th
 ### Deploy the Application
 Create PVC, storageclass and the pod that consumes the PV:
 ```sh
->> kubectl apply -f examples/kubernetes/dynamic_provisioning/specs/storageclass.yaml
->> kubectl apply -f examples/kubernetes/dynamic_provisioning/specs/claim.yaml
->> kubectl apply -f examples/kubernetes/dynamic_provisioning/specs/pod.yaml
+>> kubectl apply -f examples/kubernetes/dynamic_provisioning_s3/specs/storageclass.yaml
+>> kubectl apply -f examples/kubernetes/dynamic_provisioning_s3/specs/claim.yaml
+>> kubectl apply -f examples/kubernetes/dynamic_provisioning_s3/specs/pod.yaml
 ```
 
 ### Use Case 1: Acccess S3 files from Lustre filesystem


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix

**What is this PR about? / Why do we need it?**
In the dynamic_provisioning_s3 example, the code block that creates the StorageClass, PVC, and Pod uses pathnames for the dynamic_provisioning manifests, rather than the dynamic_provisioning_s3 example.

**What testing is done?** 
Executed the updated commands while deploying/testing the AWS CSI FSx for Lustre driver in my EKS cluster.
