### PR TITLE
Update static provisioning example to include flock mountOption

### DIFF
--- a/examples/kubernetes/static_provisioning/README.md
+++ b/examples/kubernetes/static_provisioning/README.md
@@ -13,6 +13,8 @@ spec:
   volumeMode: Filesystem
   accessModes:
     - ReadWriteMany
+  mountOptions:
+    - flock
   persistentVolumeReclaimPolicy: Recycle
   storageClassName: fsx-sc
   csi:

--- a/examples/kubernetes/static_provisioning/specs/pv.yaml
+++ b/examples/kubernetes/static_provisioning/specs/pv.yaml
@@ -8,6 +8,8 @@ spec:
   volumeMode: Filesystem
   accessModes:
     - ReadWriteMany
+  mountOptions:
+    - flock
   persistentVolumeReclaimPolicy: Recycle
   storageClassName: fsx-sc
   csi:


### PR DESCRIPTION
Add `mountOptions` to static provisioning example.  

Fixes #127 
