### PR TITLE
Fix static provisioning example

### DIFF
--- a/examples/kubernetes/static_provisioning/README.md
+++ b/examples/kubernetes/static_provisioning/README.md
@@ -16,7 +16,6 @@ spec:
   mountOptions:
     - flock
   persistentVolumeReclaimPolicy: Recycle
-  storageClassName: fsx-sc
   csi:
     driver: fsx.csi.aws.com
     volumeHandle: [FileSystemId]
@@ -30,9 +29,8 @@ Replace `volumeHandle` with `FileSystemId` and `dnsname` with `DNSName`. You can
 ```
 
 ### Deploy the Application
-Create PV, persistence volume claim (PVC), storageclass and the pod that consumes the PV:
+Create PV, persistent volume claim (PVC), and the pod that consumes the PV:
 ```sh
->> kubectl apply -f examples/kubernetes/static_provisioning/specs/storageclass.yaml
 >> kubectl apply -f examples/kubernetes/static_provisioning/specs/pv.yaml
 >> kubectl apply -f examples/kubernetes/static_provisioning/specs/claim.yaml
 >> kubectl apply -f examples/kubernetes/static_provisioning/specs/pod.yaml

--- a/examples/kubernetes/static_provisioning/specs/claim.yaml
+++ b/examples/kubernetes/static_provisioning/specs/claim.yaml
@@ -5,7 +5,8 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: fsx-sc
+  storageClassName: ""
   resources:
     requests:
       storage: 1200Gi
+  volumeName: fsx-pv

--- a/examples/kubernetes/static_provisioning/specs/pv.yaml
+++ b/examples/kubernetes/static_provisioning/specs/pv.yaml
@@ -4,14 +4,13 @@ metadata:
   name: fsx-pv
 spec:
   capacity:
-    storage: 5Gi
+    storage: 1200Gi
   volumeMode: Filesystem
   accessModes:
     - ReadWriteMany
   mountOptions:
     - flock
-  persistentVolumeReclaimPolicy: Recycle
-  storageClassName: fsx-sc
+  persistentVolumeReclaimPolicy: Retain
   csi:
     driver: fsx.csi.aws.com
     volumeHandle: fs-0199e5a63bd90f796

--- a/examples/kubernetes/static_provisioning/specs/storageclass.yaml
+++ b/examples/kubernetes/static_provisioning/specs/storageclass.yaml
@@ -1,7 +1,0 @@
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: fsx-sc
-provisioner: fsx.csi.aws.com
-mountOptions:
-  - flock


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
- the PV is only 5GI so will never get bound to the PVC -> fix the size to be 1200Gi
- this example creates a storageclass so since the PVC and PV don't get bound, a new PV gets dynamically created -> don't create a storageclass, remove storageclass from PV, and set PVC storageClassName: ""
- even with above fixed, maybe there already exists some PV in the cluster that will bind to the PVC instead of the one we intend. So set volumeName on the PVC to match the name of the PV we intend. We could also set claimRef on the PV to make the binding 2-way, but then the objects would need to be created in a specific namespace. See https://docs.openshift.com/container-platform/3.3/dev_guide/persistent_volumes.html#persistent-volumes-volumes-and-claim-prebinding for details
- Recycle retain policy is not supported -> use retain so when PVC is deleted the fsx FS won't be deleted from AWS

**What testing is done?** 
tested fixed example on my 1.14 EKS cluster