### PR TITLE
Issue #137, adding Pod Affinity to target architecture

### DIFF
--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -16,6 +16,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
       serviceAccount: fsx-csi-controller-sa
       priorityClassName: system-cluster-critical
       tolerations:

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -16,6 +16,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
       hostNetwork: true
       containers:
         - name: fsx-plugin


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Feature, Enhancement
Fixes: #137
**What is this PR about? / Why do we need it?**
To improve the behaviour of the deploying the CSI on a multi architecture node, fixing the #137 

**What testing is done?** 

Nodes on the cluster
```

NAME                                        STATUS   ROLES    AGE     VERSION               INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION                   CONTAINER-RUNTIME
ip-10-0-29-162.eu-west-1.compute.internal   Ready    <none>   2d22h   v1.15.10-eks-bac369   10.0.29.162   <none>        Amazon Linux 2                   4.14.171-136.231.amzn2.x86_64    docker://18.9.9
ip-10-0-49-41.eu-west-1.compute.internal    Ready    <none>   24h     v1.15.10-eks-bac369   10.0.49.41    <none>        Amazon Linux 2                   4.14.171-136.231.amzn2.aarch64   docker://18.9.9
ip-10-0-87-226.eu-west-1.compute.internal   Ready    <none>   25h     v1.15.10-eks-bac369   10.0.87.226   <none>        Amazon Linux 2                   4.14.171-136.231.amzn2.aarch64   docker://18.9.9
ip-10-0-93-165.eu-west-1.compute.internal   Ready    <none>   2d22h   v1.15.10-eks-bac369   10.0.93.165   <none>        Amazon Linux 2                   4.14.171-136.231.amzn2.x86_64    docker://18.9.9
```

Pods

```
NAME                                        STATUS   ROLES    AGE     VERSION               INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION                   CONTAINER-RUNTIME
ip-10-0-29-162.eu-west-1.compute.internal   Ready    <none>   2d22h   v1.15.10-eks-bac369   10.0.29.162   <none>        Amazon Linux 2                   4.14.171-136.231.amzn2.x86_64    docker://18.9.9
ip-10-0-49-41.eu-west-1.compute.internal    Ready    <none>   24h     v1.15.10-eks-bac369   10.0.49.41    <none>        Amazon Linux 2                   4.14.171-136.231.amzn2.aarch64   docker://18.9.9
ip-10-0-87-226.eu-west-1.compute.internal   Ready    <none>   24h     v1.15.10-eks-bac369   10.0.87.226   <none>        Amazon Linux 2                   4.14.171-136.231.amzn2.aarch64   docker://18.9.9
ip-10-0-93-165.eu-west-1.compute.internal   Ready    <none>   2d22h   v1.15.10-eks-bac369   10.0.93.165   <none>        Amazon Linux 2                   4.14.171-136.231.amzn2.x86_64    docker://18.9.9
```

```
kube-system         fsx-csi-controller-74f94778d6-7wcx5                        2/2     Running            0          15m
kube-system         fsx-csi-controller-74f94778d6-8j79s                        2/2     Running            0          15m
kube-system         fsx-csi-node-2kd9x                                         3/3     Running            0          15m
kube-system         fsx-csi-node-9cvrp                                         3/3     Running            0          15m
kube-system         fsx-csi-node-lrwvp                                         3/3     Running            0          15m
kube-system         fsx-csi-node-pkjwd                                         3/3     Running            0          16m
```

/check-cla