### PR TITLE
optimization: cache go mod during docker build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v1
       - name: Create Helm chart
         run: |
-          tar cvzf helm-chart.tgz helm 
+          tar cvzf helm-chart.tgz helm
       - name: Create Release
         id: create-release
         uses: actions/create-release@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,12 @@
 
 FROM golang:1.13.4-stretch as builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-fsx-csi-driver
+
+# Cache go modules
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
 ADD . .
 RUN make
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
cache go mod during docker build