### PR TITLE
Replace module vbom.ml/util with github.com/fvbommel/util

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,52 +16,32 @@ require (
 	k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 )
 
-replace k8s.io/api => k8s.io/api v0.17.0
-
-replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.17.0
-
-replace k8s.io/apimachinery => k8s.io/apimachinery v0.17.1-beta.0
-
-replace k8s.io/apiserver => k8s.io/apiserver v0.17.0
-
-replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.17.0
-
-replace k8s.io/client-go => k8s.io/client-go v0.17.0
-
-replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.17.0
-
-replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.17.0
-
-replace k8s.io/code-generator => k8s.io/code-generator v0.17.1-beta.0
-
-replace k8s.io/component-base => k8s.io/component-base v0.17.0
-
-replace k8s.io/cri-api => k8s.io/cri-api v0.17.1-beta.0
-
-replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.17.0
-
-replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.17.0
-
-replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.17.0
-
-replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.17.0
-
-replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.17.0
-
-replace k8s.io/kubectl => k8s.io/kubectl v0.17.0
-
-replace k8s.io/kubelet => k8s.io/kubelet v0.17.0
-
-replace k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.17.0
-
-replace k8s.io/metrics => k8s.io/metrics v0.17.0
-
-replace k8s.io/node-api => k8s.io/node-api v0.17.0
-
-replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.17.0
-
-replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.17.0
-
-replace k8s.io/sample-controller => k8s.io/sample-controller v0.17.0
+replace (
+	k8s.io/api => k8s.io/api v0.17.0
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.17.0
+	k8s.io/apimachinery => k8s.io/apimachinery v0.17.1-beta.0
+	k8s.io/apiserver => k8s.io/apiserver v0.17.0
+	k8s.io/cli-runtime => k8s.io/cli-runtime v0.17.0
+	k8s.io/client-go => k8s.io/client-go v0.17.0
+	k8s.io/cloud-provider => k8s.io/cloud-provider v0.17.0
+	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.17.0
+	k8s.io/code-generator => k8s.io/code-generator v0.17.1-beta.0
+	k8s.io/component-base => k8s.io/component-base v0.17.0
+	k8s.io/cri-api => k8s.io/cri-api v0.17.1-beta.0
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.17.0
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.17.0
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.17.0
+	k8s.io/kube-proxy => k8s.io/kube-proxy v0.17.0
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.17.0
+	k8s.io/kubectl => k8s.io/kubectl v0.17.0
+	k8s.io/kubelet => k8s.io/kubelet v0.17.0
+	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.17.0
+	k8s.io/metrics => k8s.io/metrics v0.17.0
+	k8s.io/node-api => k8s.io/node-api v0.17.0
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.17.0
+	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.17.0
+	k8s.io/sample-controller => k8s.io/sample-controller v0.17.0
+	vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787
+)
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,7 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787/go.mod h1:AlRx4sdoz6EdWGYPMeunQWYf46cKnq7J4iVvLgyb5cY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix due to the dependency change.

**What is this PR about? / Why do we need it?**
`vbom.ml/util` has been changed and we need to replace the dependency to new repo to build the project. 

**What testing is done?** 

```
GOPROXY=direct make aws-fsx-csi-driver
```

build successfully, I didn't run e2e test. leave it to CI. 