### PR TITLE
Add support for DataCompressionType

### DIFF
--- a/examples/kubernetes/dynamic_provisioning/README.md
+++ b/examples/kubernetes/dynamic_provisioning/README.md
@@ -22,6 +22,7 @@ parameters:
 * perUnitStorageThroughput (Optional) - for deployment type PERSISTENT_1, customer can specify the storage throughput. Default: "200". Note that customer has to specify as a string here like "200" or "100" etc.
 * storageType (Optional) - for deployment type PERSISTENT_1, customer can specify the storage type, either SSD or HDD. Default: "SSD"
 * driveCacheType (Required if storageType is "HDD") - for HDD PERSISTENT_1, specify the type of drive cache, either NONE or READ.
+* dataCompressionType (Optional) - sets the data compression configuration for the file system, either NONE or LZ4. Default: "NONE"
 * automaticBackupRetentionDays (Optional) - The number of days to retain automatic backups. The default is to retain backups for 7 days. Setting this value to 0 disables the creation of automatic backups. The maximum retention period for backups is 35 days
 * dailyAutomaticBackupStartTime (Optional) - The preferred time to take daily automatic backups, formatted HH:MM in the UTC time zone.
 * copyTagsToBackups (Optional) - A boolean flag indicating whether tags for the file system should be copied to backups. This value defaults to false. If it's set to true, all tags for the file system are copied to all automatic and user-initiated backups where the user doesn't specify tags. If this value is true, and you specify one or more tags, only the specified tags are copied to backups. If you specify one or more tags when creating a user-initiated backup, no tags are copied from the file system, regardless of this value.

--- a/examples/kubernetes/dynamic_provisioning_s3/README.md
+++ b/examples/kubernetes/dynamic_provisioning_s3/README.md
@@ -28,6 +28,8 @@ parameters:
 * perUnitStorageThroughput (Optional) - for deployment type PERSISTENT_1, customer can specify the storage throughput. Default: "200". Note that customer has to specify as a string here like "200" or "100" etc.
 * storageType (Optional) - for deployment type PERSISTENT_1, customer can specify the storage type, either SSD or HDD. Default: "SSD"
 * driveCacheType (Required if storageType is "HDD") - for HDD PERSISTENT_1, specify the type of drive cache, either NONE or READ.
+* dataCompressionType (Optional) - sets the data compression configuration for the file system, either NONE or LZ4. Default: "NONE"
+
 
 Note:
 - S3 Bucket in s3ImportPath and s3ExportPath must be same, otherwise the driver can not create FSx for lustre successfully.

--- a/go.sum
+++ b/go.sum
@@ -540,7 +540,10 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+<<<<<<< HEAD
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
+=======
+>>>>>>> cb82055 (Add support for DataCompressionType)
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -577,6 +580,11 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+<<<<<<< HEAD
+=======
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+>>>>>>> cb82055 (Add support for DataCompressionType)
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -613,7 +621,10 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+<<<<<<< HEAD
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
+=======
+>>>>>>> cb82055 (Add support for DataCompressionType)
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -76,6 +76,7 @@ type FileSystemOptions struct {
 	KmsKeyId                      string
 	PerUnitStorageThroughput      int64
 	StorageType                   string
+	DataCompressionType           string
 	DriveCacheType                string
 	DailyAutomaticBackupStartTime string
 	AutomaticBackupRetentionDays  int64
@@ -140,6 +141,10 @@ func (c *cloud) CreateFileSystem(ctx context.Context, volumeName string, fileSys
 
 	if fileSystemOptions.DriveCacheType != "" {
 		lustreConfiguration.SetDriveCacheType(fileSystemOptions.DriveCacheType)
+	}
+
+	if fileSystemOptions.DataCompressionType != "" {
+		lustreConfiguration.SetDataCompressionType(fileSystemOptions.DataCompressionType)
 	}
 
 	if fileSystemOptions.PerUnitStorageThroughput != 0 {

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -282,6 +282,130 @@ func TestCreateFileSystem(t *testing.T) {
 			},
 		},
 		{
+			name: "success: normal with dataCompression LZ4",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockFSx := mocks.NewMockFSx(mockCtl)
+				c := &cloud{
+					fsx: mockFSx,
+				}
+
+				req := &FileSystemOptions{
+					CapacityGiB:         volumeSizeGiB,
+					SubnetId:            subnetId,
+					SecurityGroupIds:    securityGroupIds,
+					DeploymentType:      fsx.LustreDeploymentTypePersistent1,
+					StorageType:         fsx.StorageTypeHdd,
+					DataCompressionType: dataCompressionType,
+					DriveCacheType:      fsx.DriveCacheTypeNone,
+				}
+
+				output := &fsx.CreateFileSystemOutput{
+					FileSystem: &fsx.FileSystem{
+						FileSystemId:    aws.String(fileSystemId),
+						StorageCapacity: aws.Int64(volumeSizeGiB),
+						DNSName:         aws.String(dnsname),
+						LustreConfiguration: &fsx.LustreFileSystemConfiguration{
+							MountName:           aws.String(mountName),
+							DeploymentType:      aws.String(fsx.LustreDeploymentTypePersistent1),
+							DataCompressionType: aws.String(fsx.DataCompressionTypeLz4),
+							DriveCacheType:      aws.String(fsx.DriveCacheTypeNone),
+						},
+					},
+				}
+				ctx := context.Background()
+				mockFSx.EXPECT().CreateFileSystemWithContext(gomock.Eq(ctx), gomock.Any()).Return(output, nil)
+				resp, err := c.CreateFileSystem(ctx, volumeName, req)
+				if err != nil {
+					t.Fatalf("CreateFileSystem is failed: %v", err)
+				}
+
+				if resp == nil {
+					t.Fatal("resp is nil")
+				}
+
+				if resp.FileSystemId != fileSystemId {
+					t.Fatalf("FileSystemId mismatches. actual: %v expected: %v", resp.FileSystemId, fileSystemId)
+				}
+
+				if resp.CapacityGiB != volumeSizeGiB {
+					t.Fatalf("CapacityGiB mismatches. actual: %v expected: %v", resp.CapacityGiB, volumeSizeGiB)
+				}
+
+				if resp.DnsName != dnsname {
+					t.Fatalf("DnsName mismatches. actual: %v expected: %v", resp.DnsName, dnsname)
+				}
+
+				if resp.MountName != mountName {
+					t.Fatalf("MountName mismatches. actual: %v expected: %v", resp.MountName, mountName)
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "success: normal with dataCompression None",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockFSx := mocks.NewMockFSx(mockCtl)
+				c := &cloud{
+					fsx: mockFSx,
+				}
+
+				req := &FileSystemOptions{
+					CapacityGiB:         volumeSizeGiB,
+					SubnetId:            subnetId,
+					SecurityGroupIds:    securityGroupIds,
+					DeploymentType:      fsx.LustreDeploymentTypePersistent1,
+					StorageType:         fsx.StorageTypeHdd,
+					DataCompressionType: fsx.DataCompressionTypeNone,
+					DriveCacheType:      fsx.DriveCacheTypeNone,
+				}
+
+				output := &fsx.CreateFileSystemOutput{
+					FileSystem: &fsx.FileSystem{
+						FileSystemId:    aws.String(fileSystemId),
+						StorageCapacity: aws.Int64(volumeSizeGiB),
+						DNSName:         aws.String(dnsname),
+						LustreConfiguration: &fsx.LustreFileSystemConfiguration{
+							MountName:           aws.String(mountName),
+							DeploymentType:      aws.String(fsx.LustreDeploymentTypePersistent1),
+							DataCompressionType: aws.String(fsx.DataCompressionTypeNone),
+							DriveCacheType:      aws.String(fsx.DriveCacheTypeNone),
+						},
+					},
+				}
+				ctx := context.Background()
+				mockFSx.EXPECT().CreateFileSystemWithContext(gomock.Eq(ctx), gomock.Any()).Return(output, nil)
+				resp, err := c.CreateFileSystem(ctx, volumeName, req)
+				if err != nil {
+					t.Fatalf("CreateFileSystem is failed: %v", err)
+				}
+
+				if resp == nil {
+					t.Fatal("resp is nil")
+				}
+
+				if resp.FileSystemId != fileSystemId {
+					t.Fatalf("FileSystemId mismatches. actual: %v expected: %v", resp.FileSystemId, fileSystemId)
+				}
+
+				if resp.CapacityGiB != volumeSizeGiB {
+					t.Fatalf("CapacityGiB mismatches. actual: %v expected: %v", resp.CapacityGiB, volumeSizeGiB)
+				}
+
+				if resp.DnsName != dnsname {
+					t.Fatalf("DnsName mismatches. actual: %v expected: %v", resp.DnsName, dnsname)
+				}
+
+				if resp.MountName != mountName {
+					t.Fatalf("MountName mismatches. actual: %v expected: %v", resp.MountName, mountName)
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
 			name: "failure: incompatible deploymentType and storageTypeHdd",
 			testFunc: func(t *testing.T) {
 				mockCtl := gomock.NewController(t)

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -39,6 +39,7 @@ func TestCreateFileSystem(t *testing.T) {
 		s3ImportPath                        = "s3://fsx-s3-data-repository"
 		s3ExportPath                        = "s3://fsx-s3-data-repository/export"
 		deploymentType                      = fsx.LustreDeploymentTypeScratch2
+		dataCompressionType                 = "LZ4"
 		mountName                           = "fsx"
 		kmsKeyId                            = "arn:aws:kms:us-east-1:215474938041:key/48313a27-7d88-4b51-98a4-fdf5bc80dbbe"
 		perUnitStorageThroughput      int64 = 200

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -45,6 +45,7 @@ const (
 	volumeParamsS3ImportPath                  = "s3ImportPath"
 	volumeParamsS3ExportPath                  = "s3ExportPath"
 	volumeParamsDeploymentType                = "deploymentType"
+	volumeParamsDataCompressionType           = "dataCompressionType"
 	volumeParamsKmsKeyId                      = "kmsKeyId"
 	volumeParamsPerUnitStorageThroughput      = "perUnitStorageThroughput"
 	volumeParamsStorageType                   = "storageType"
@@ -95,6 +96,10 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 	if val, ok := volumeParams[volumeParamsDeploymentType]; ok {
 		fsOptions.DeploymentType = val
+	}
+
+	if val, ok := volumeParams[volumeParamsDataCompressionType]; ok {
+		fsOptions.DataCompressionType = val
 	}
 
 	if val, ok := volumeParams[volumeParamsKmsKeyId]; ok {


### PR DESCRIPTION
Hello, great maintainers! I am an MLOps infra engineer.

**Is this a bug fix or adding new feature?**

Feature

**What is this PR about? / Why do we need it?**

- Support DataCompressionType for Lustre, which is newly introduced. The compression feature is useful, especially when the data could be extremely large like Machine Learning application, so I think it would be great if we can support it.
- Update aws-sdk-go version to 1.38.50, in order to use the updated API.

References:
- blog: https://aws.amazon.com/about-aws/whats-new/2021/05/amazon-fsx-for-lustre-now-supports-data-compression/
- API: https://docs.aws.amazon.com/sdk-for-go/api/service/fsx/
- aws-sdk-go v1.38.50: https://github.com/aws/aws-sdk-go/compare/v1.38.49...v1.38.50

**What testing is done?** 

~~Not yet done.
Since this is my first PR for this repository, and also involves update of `aws-sdk-go`, I wanted to create a draft PR as quick as possible first.~~

Update: done testing. Please see the PR checkers..

Now I am doing:
- [x] Add unit tests for `controller.go` and `cloud.go`
- [x] Modify README

~~and will update this PR in a few days.~~

Update: done all above.

If my PR does not follow any of your design intention or developer guide, please let me know..

Thank you :)

