### PR TITLE
Updated helm chart dns config and imagePullSecrets

### DIFF
--- a/charts/aws-fsx-csi-driver/Chart.yaml
+++ b/charts/aws-fsx-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.4.0"
 name: aws-fsx-csi-driver
 description: A Helm chart for AWS FSx for Lustre CSI Driver
-version: 0.2.0
+version: 0.3.0
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/kubernetes-sigs/aws-fsx-csi-driver
 sources:

--- a/charts/aws-fsx-csi-driver/templates/controller.yaml
+++ b/charts/aws-fsx-csi-driver/templates/controller.yaml
@@ -19,6 +19,12 @@ spec:
       tolerations:
           - key: CriticalAddonsOnly
             operator: Exists
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: fsx-plugin
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/aws-fsx-csi-driver/templates/node.yaml
+++ b/charts/aws-fsx-csi-driver/templates/node.yaml
@@ -14,6 +14,19 @@ spec:
         {{- include "helm.selectorLabels" . | nindent 8 }}-daemonset
     spec:
       hostNetwork: true
+      {{- if .Values.nodeService.dnsPolicy }}
+      dnsPolicy: "{{ .Values.nodeService.dnsPolicy }}"
+      {{- end }}
+      {{- with .Values.nodeService.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: fsx-plugin
           securityContext:

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -47,8 +47,18 @@ nodeService:
 
     resources: {}
 
+  dnsPolicy: ""
+  dnsConfig: {}
+    # Example config which uses the AWS nameservers
+    # dnsPolicy: "None"
+    # dnsConfig:
+    #   nameservers:
+    #     - 169.254.169.253
+
 nameOverride: ""
 fullnameOverride: ""
+
+imagePullSecrets: []
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New Feature

**What is this PR about? / Why do we need it?**
Adding dnsPolicy, dnsConfig, and imagePullSecrets to the helm chart.

**What testing is done?** 
Ran helm template and also successfully deployed the chart locally

Note: A similar change was made to the EFS CSI driver here: https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/288

Fixes #187 