### PR TITLE
Release 0.5.0 part 2/3: helm and kustomize

### DIFF
--- a/CHANGELOG-0.x.md
+++ b/CHANGELOG-0.x.md
@@ -1,3 +1,18 @@
+# v0.5.0
+
+### New features
+* Add support for Lustre compression ([#186](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/186), [@wuxingro](https://github.com/wuxingro))
+
+### Misc.
+* Post-release v0.4.0 ([#166](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/166), [@ayberk](https://github.com/ayberk))
+* Fix CI ([#172](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/172), [@wongma7](https://github.com/wongma7))
+* Add self to OWNERS ([#173](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/173), [@ayberk](https://github.com/ayberk))
+* Update README for stable release ([#177](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/177), [@dimitricole](https://github.com/dimitricole))
+* Updated helm chart dns config and imagePullSecrets ([#188](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/188), [@nxf5025](https://github.com/nxf5025))
+* go mod tidy && go mod vendor ([#192](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/192), [@wongma7](https://github.com/wongma7))
+* Document the stable kustomize overlay not dev ([#193](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/193), [@wongma7](https://github.com/wongma7))
+* Helm chart 1.0 ([#194](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/194), [@wongma7](https://github.com/wongma7))
+
 # v0.4.0
 [Documentation](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/blob/v0.4.0/docs/README.md)
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 PKG=github.com/kubernetes-sigs/aws-fsx-csi-driver
 IMAGE?=amazon/aws-fsx-csi-driver
-VERSION=v0.4.0
+VERSION=v0.5.0
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE}"

--- a/charts/aws-fsx-csi-driver/CHANGELOG.md
+++ b/charts/aws-fsx-csi-driver/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Helm chart
 
+# v1.1.0
+* Use driver 0.5.0
+
 # v1.0.0
 * Remove support for Helm 2
 * Reorganize values to be more consistent with EFS and EBS helm charts

--- a/charts/aws-fsx-csi-driver/Chart.yaml
+++ b/charts/aws-fsx-csi-driver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "0.4.0"
+appVersion: "0.5.0"
 name: aws-fsx-csi-driver
 description: A Helm chart for AWS FSx for Lustre CSI Driver
-version: 1.0.0
+version: 1.1.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-fsx-csi-driver
 sources:

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: amazon/aws-fsx-csi-driver
-  tag: v0.4.0
+  tag: v0.5.0
   pullPolicy: IfNotPresent
 
 sidecars:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -31,7 +31,7 @@ spec:
           tolerationSeconds: 300
       containers:
         - name: fsx-plugin
-          image: amazon/aws-fsx-csi-driver:v0.4.0
+          image: amazon/aws-fsx-csi-driver:v0.5.0
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         - name: fsx-plugin
           securityContext:
             privileged: true
-          image: amazon/aws-fsx-csi-driver:v0.4.0
+          image: amazon/aws-fsx-csi-driver:v0.5.0
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../../base
+images:
+  - name: amazon/aws-fsx-csi-driver
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-fsx-csi-driver
+    newTag: v0.5.0

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -1,13 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- ../../base
+  - ../../base
 images:
-- name: amazon/aws-fsx-csi-driver
-  newTag: v0.4.0
-- name: quay.io/k8scsi/csi-provisioner
-  newTag: v1.3.0
-- name: quay.io/k8scsi/livenessprobe
-  newTag: v1.1.0
-- name: quay.io/k8scsi/csi-node-driver-registrar
-  newTag: v1.1.0
+  - name: amazon/aws-fsx-csi-driver
+    newTag: v0.5.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,9 +8,10 @@
 The [Amazon FSx for Lustre](https://aws.amazon.com/fsx/lustre/) Container Storage Interface (CSI) Driver implements [CSI](https://github.com/container-storage-interface/spec/blob/master/spec.md) specification for container orchestrators (CO) to manage lifecycle of Amazon FSx for Lustre filesystems.
 
 ### CSI Specification Compability Matrix
-| AWS FSx for Lustre CSI Driver \ CSI Version       | v0.3.0| v1.1.0 |
+| AWS FSx for Lustre CSI Driver \ CSI Version       | v0.3.0| v1.x.x |
 |---------------------------------------------------|-------|--------|
 | master branch                                     | no    | yes    |
+| v0.5.0                                            | no    | yes    |
 | v0.4.0                                            | no    | yes    |
 | v0.3.0                                            | no    | yes    |
 | v0.2.0                                            | no    | yes    |
@@ -26,18 +27,20 @@ The following CSI interfaces are implemented:
 Following sections are Kubernetes specific. If you are Kubernetes user, use followings for driver features, installation steps and examples.
 
 ### Kubernetes Version Compability Matrix
-| AWS FSx for Lustre CSI Driver \ Kubernetes Version| v1.11 | v1.12 | v1.13 | v1.14 | v1.15+ |
-|---------------------------------------------------|-------|-------|-------|-------|--------|
-| master branch                                     | no    | no    | no    | yes   | yes    |
-| v0.4.0                                            | no    | no    | no    | yes   | yes    |
-| v0.3.0                                            | no    | no    | no    | yes   | yes    |
-| v0.2.0                                            | no    | no    | no    | yes   | yes    |
-| v0.1.0                                            | yes   | yes   | yes   | no    | no     |
+| AWS FSx for Lustre CSI Driver \ Kubernetes Version| v1.11 | v1.12 | v1.13 | v1.14-16 | v1.17+ |
+|---------------------------------------------------|-------|-------|-------|----------|--------|
+| master branch                                     | no    | no    | no    | no       | yes    |
+| v0.5.0                                            | no    | no    | no    | no       | yes    |
+| v0.4.0                                            | no    | no    | no    | yes      | yes    |
+| v0.3.0                                            | no    | no    | no    | yes      | yes    |
+| v0.2.0                                            | no    | no    | no    | yes      | yes    |
+| v0.1.0                                            | yes   | yes   | yes   | no       | no     |
 
 ### Container Images
 |FSx CSI Driver Version     | Image                               |
 |---------------------------|-------------------------------------|
 |master branch              |amazon/aws-fsx-csi-driver:latest     |
+|v0.5.0                     |amazon/aws-fsx-csi-driver:v0.5.0     |
 |v0.4.0                     |amazon/aws-fsx-csi-driver:v0.4.0     |
 |v0.3.0                     |amazon/aws-fsx-csi-driver:v0.3.0     |
 |v0.2.0                     |amazon/aws-fsx-csi-driver:v0.2.0     |
@@ -105,7 +108,7 @@ kubectl apply -f secret.yaml
 
 #### Deploy driver
 ```sh
-kubectl apply -k "github.com/kubernetes-sigs/aws-fsx-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-0.4"
+kubectl apply -k "github.com/kubernetes-sigs/aws-fsx-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-0.5"
 ```
 
 Alternatively, you could also install the driver using helm:
@@ -116,7 +119,7 @@ helm repo update
 helm upgrade --install aws-fsx-csi-driver --namespace kube-system aws-fsx-csi-driver/aws-fsx-csi-driver
 ```
 
-###### Upgrading from version release-0.4 to master of the kustomize configuration
+###### Upgrading from version release-0.4 to release-0.5 of the kustomize configuration
 
 In the master branch and the next release there are breaking changes that require you to `--force` to `kubectl apply`:
 ```sh

--- a/hack/release
+++ b/hack/release
@@ -1,0 +1,167 @@
+#!/usr/local/bin/python3
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import hashlib
+import json
+import os
+import requests
+
+
+def file_sha512(fileName, repoName):
+    download(fileName, repoName)
+    with open(fileName, "rb") as file:
+        m = hashlib.sha512()
+        blob = file.read()
+        m.update(blob)
+        print(
+            "[{}](https://github.com/{}/archive/{}) | `{}`".format(
+                fileName, repoName, fileName, m.hexdigest()
+            )
+        )
+    os.remove(fileName)
+
+
+def download(fileName, repoName):
+    url = "https://github.com/{}/archive/{}".format(repoName, fileName)
+    r = requests.get(url, allow_redirects=True)
+    open(fileName, "wb").write(r.content)
+
+
+def print_header(repo, version):
+    # Title
+    print("# {}".format(version))
+
+    # documentation section
+    print("[Documentation](https://github.com/{}/blob/{}/docs/README.md)\n".format(repo, version))
+
+    # sha512
+    print("filename  | sha512 hash")
+    print("--------- | ------------")
+    file_sha512(version + ".zip", repo)
+    file_sha512(version + ".tar.gz", repo)
+
+
+class Github:
+    def __init__(self, user, token):
+        self._url = "https://api.github.com"
+        self._user = user
+        self._token = token
+
+    def get_commits(self, repo, since):
+        resp = requests.get(
+            "{}/repos/{}/compare/{}...master".format(self._url, repo, since),
+            auth=(self._user, self._token),
+        )
+        jsonResp = json.loads(resp.content)
+        return jsonResp["commits"]
+
+    def to_pr_numbers(self, repo, commit):
+        sha = commit["sha"]
+        resp = requests.get(
+            "{}/repos/{}/commits/{}/pulls".format(self._url, repo, sha),
+            headers={"Accept": "application/vnd.github.groot-preview+json"},
+            auth=(self._user, self._token),
+        )
+        jsonResp = json.loads(resp.content)
+        ret = []
+        for pr in jsonResp:
+            ret.append(pr["number"])
+
+        return ret
+
+    def get_pr(self, repo, pr_number):
+        resp = requests.get(
+            "{}/repos/{}/pulls/{}".format(self._url, repo, pr_number),
+            auth=(self._user, self._token),
+        )
+        jsonResp = json.loads(resp.content)
+        return jsonResp
+
+    def print_release_note(self, repo, since):
+        # remove merge commits
+        commits = self.get_commits(repo, since)
+        commits = filter(
+            lambda c: not c["commit"]["message"].startswith("Merge pull request"), commits
+        )
+        pr_numbers = set()
+        for commit in commits:
+            numbers = self.to_pr_numbers(repo, commit)
+            for pr in numbers:
+                pr_numbers.add(pr)
+
+        # dedupe pr numbers
+        pr_numbers = sorted(list(pr_numbers))
+
+        for number in pr_numbers:
+            pr = self.get_pr(repo, number)
+            if "user" in pr:
+                user = pr["user"]["login"]
+                print(
+                    "* {} ([#{}]({}), [@{}](https://github.com/{}))".format(
+                        pr["title"], pr["number"], pr["html_url"], user, user
+                    )
+                )
+
+
+def print_sha(args):
+    version = args.version
+    repo = args.repo
+    print_header(repo, version)
+
+
+def print_notes(args):
+    repo = args.repo
+    since = args.since
+    user = args.github_user
+    token = args.github_token
+
+    g = Github(user, token)
+    g.print_release_note(repo, since)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate release CHANGELOG")
+    parser.add_argument(
+        "--repo",
+        metavar="repo",
+        type=str,
+        default="kubernetes-sigs/aws-fsx-csi-driver",
+        help="the full github repository name",
+    )
+    parser.add_argument(
+        "--github-user", metavar="user", type=str, help="the github user for github api"
+    )
+    parser.add_argument(
+        "--github-token", metavar="token", type=str, help="the github token for github api"
+    )
+
+    subParsers = parser.add_subparsers(title="subcommands", description="[note|sha]")
+
+    noteParser = subParsers.add_parser("note", help="generate release notes")
+    noteParser.add_argument(
+        "--since", metavar="since", type=str, required=True, help="since version tag"
+    )
+    noteParser.set_defaults(func=print_notes)
+
+    shaParser = subParsers.add_parser("sha", help="generate SHA for released version tag")
+    shaParser.add_argument(
+        "--version", metavar="version", type=str, required=True, help="the version to release"
+    )
+    shaParser.set_defaults(func=print_sha)
+
+    args = parser.parse_args()
+    args.func(args)


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

/hold
this must merge after https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/198 has merged and images are verified.

While updating the kustomize overlay I remembered we are missing a stable ECR overlay. We now push  the image there so I have added the overlay in commit 1.

In addition, the quay patch in the stable overlay is obsolete so I removed it in commit 2.

**What testing is done?** 
