### PR TITLE
make the helm chart secret name configurable

### DIFF
--- a/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
@@ -51,13 +51,13 @@ spec:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: aws-secret
+                  name: {{ .Values.controller.secretName }}
                   key: key_id
                   optional: true
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: aws-secret
+                  name: {{ .Values.controller.secretName }}
                   key: access_key
                   optional: true
           volumeMounts:

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -38,6 +38,11 @@ controller:
     #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/fsx-csi-role
     name: fsx-csi-controller-sa
     annotations: {}
+  # The name of the secret holding the API keys of the IAM user to be used
+  # by the csi driver to control FSx, if required. Expected K8s Secret's data 
+  # keys are `key_id` for the AWS `Access Key ID`, and `access_key` for the 
+  # AWS `Secret Access Key`:
+  secretName: aws-secret
   tolerations: []
 
 node:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

It's a feature, a small enhancement to the Helm chart.

**What is this PR about? / Why do we need it?**

It's backward compatible, and it makes the K8s secret name (previously hardcoded to `aws-secret`) configurable.  It's pretty useful to be able to name your secrets something other than _aws-secret_ to clarify what the secret is for when looking at it from the K8s side, and to be able to figure out which secret is the one with the IAM keys for the aws-fsx-csi-driver when you have many secrets in the same namespace.

**What testing is done?** 

Running the helm template command returns exactly the same result before and after (unless you override the Helm value, then the value does changes in the deployment section to whatever you specified).

**Also**

Maybe the same kind of configurability might be done on the _kustomize_ side of things, but I prefer to make this a separate PR.
