### PR TITLE
Add multiple StorageClass resources from values

### DIFF
--- a/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
@@ -22,6 +22,9 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- with .Values.controller.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
         {{- with .Values.controller.nodeSelector }}

--- a/charts/aws-fsx-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-fsx-csi-driver/templates/node-daemonset.yaml
@@ -21,6 +21,9 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- with .Values.node.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
         {{- with .Values.node.nodeSelector }}

--- a/charts/aws-fsx-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-fsx-csi-driver/templates/storageclass.yaml
@@ -1,0 +1,28 @@
+{{- $labels := include "aws-fsx-csi-driver.labels" . -}}
+{{- range .Values.storageClasses }}
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  labels:
+    {{- $labels | nindent 4 }}
+{{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+  name: {{ .name }}
+{{- with .annotations }}
+  annotations:
+    {{ toYaml . }}
+{{- end }}
+provisioner: fsx.csi.aws.com
+{{- with .mountOptions }}
+mountOptions:
+  {{- toYaml . | nindent 2}}
+{{- end }}
+{{- with .parameters }}
+parameters:
+  {{- toYaml . | nindent 2}}
+{{- end }}
+reclaimPolicy: {{ .reclaimPolicy }}
+volumeBindingMode: {{ .volumeBindingMode }}
+{{- end }}

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -28,6 +28,7 @@ sidecars:
     resources: {}
 
 controller:
+  affinity: {}
   nodeSelector: {}
   replicaCount: 2
   resources: {}
@@ -41,6 +42,7 @@ controller:
   tolerations: []
 
 node:
+  affinity: {}
   nodeSelector: {}
   resources: {}
   dnsPolicy: ClusterFirst

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -65,3 +65,25 @@ nameOverride: ""
 fullnameOverride: ""
 
 imagePullSecrets: []
+
+storageClasses: []
+## full API docs https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#storageclass-v1-storage-k8s-io
+## Add StorageClass resources like:
+#  - name: fsx-sc
+#    labels: {}
+#    #  key: value
+#    annotations: {}
+#    #  storageclass.kubernetes.io/is-default-class: "true"
+#    mountOptions:
+#    - flock
+#    parameters:
+#      subnetId: subnet-0eabfaa81fb22bcaf
+#      securityGroupIds: sg-068000ccf82dfba88
+#      deploymentType: PERSISTENT_1
+#      automaticBackupRetentionDays: "1"
+#      dailyAutomaticBackupStartTime: "00:00"
+#      copyTagsToBackups: "true"
+#      perUnitStorageThroughput: "200"
+#      dataCompressionType: "NONE"
+#    reclaimPolicy: Delete
+#    volumeBindingMode: Immediate


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
feature

**What is this PR about? / Why do we need it?**
- [x] this feature will provide the ability to deploy multiple `StorageClass` resources part of helm install process, this is needed when bootstrapping  a cluster for example, so an automated process will be able to install the chart + storage class in a single command.
- [x] provide advanced affinity configuration for controller/nodes, for example controller pods should be distributed to non application nodes, and daemonset should be distributed to nodes that also run pods that need FSX

**What testing is done?** 
`helm template`
`helm lint`
and installation attempt on local k8s cluster