### PR TITLE
Use latest buildx github action and build target platform from build platform 

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -7,39 +7,25 @@ jobs:
     if: github.repository == 'kubernetes-sigs/aws-fsx-csi-driver'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: crazy-max/ghaction-docker-buildx@v3
-      with:
-        buildx-version: latest
-        qemu-version: latest
-    - name: Push to Github registry
-      run: |
-        USER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
-        BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)
-        IMAGE=aws-fsx-csi-driver
-        if [ "$BRANCH" = "master" ]; then
-          TAG="latest"
-        else
-          TAG=$BRANCH
-        fi
-        docker login docker.pkg.github.com -u $USER -p ${{ secrets.REGISTRY_TOKEN }}
-        docker build -t aws-fsx-csi-driver .
-        docker tag aws-fsx-csi-driver docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG
-        docker push docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG
-    - name: Push to Dockerhub registry
-      run: |
-        BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)
-        REPO=amazon/aws-fsx-csi-driver
-        if [ "$BRANCH" = "master" ]; then
-          TAG="latest"
-        else
-          TAG=$BRANCH
-        fi
-        docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
-        docker buildx build \
-          -t $REPO:$TAG \
-          --platform=linux/arm64,linux/amd64 \
-          --progress plain \
-          --push .
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Push to Dockerhub registry
+        run: |
+          BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)
+          REPO=amazon/aws-fsx-csi-driver
+          if [ "$BRANCH" = "master" ]; then
+            TAG="latest"
+          else
+            TAG=$BRANCH
+          fi
+          docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+          docker buildx build \
+            -t $REPO:$TAG \
+            --platform=linux/arm64,linux/amd64 \
+            --progress plain \
+            --push .

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.16.8-stretch as builder
+FROM --platform=$BUILDPLATFORM golang:1.16.8-stretch as builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-fsx-csi-driver
 
 ARG TARGETOS
@@ -24,7 +24,7 @@ COPY . .
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make aws-fsx-csi-driver
 
-FROM amazonlinux:2
+FROM amazonlinux:2 AS linux-amazon
 RUN yum update -y
 RUN yum install util-linux libyaml -y \
     && amazon-linux-extras install -y lustre2.10

--- a/hack/e2e/README.md
+++ b/hack/e2e/README.md
@@ -41,7 +41,16 @@ To commit changes and submit them as a PR back to the ebs repo:
 
 ```
 git diff ebs/master:hack/e2e HEAD:hack/e2e > /tmp/hack_e2e.diff
-cd $GOPATH/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
+pushd $GOPATH/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
+git apply --reject --directory hack/e2e /tmp/hack_e2e.diff
+git commit
+```
+
+To consume newer changes from the ebs repo:
+
+```
+git fetch ebs
+git diff HEAD:hack/e2e ebs/master:hack/e2e > /tmp/hack_e2e.diff
 git apply --reject --directory hack/e2e /tmp/hack_e2e.diff
 git commit
 ```

--- a/hack/e2e/ecr.sh
+++ b/hack/e2e/ecr.sh
@@ -11,14 +11,15 @@ function ecr_build_and_push() {
   IMAGE_NAME=${3}
   IMAGE_TAG=${4}
   set +e
-  if docker images | grep "${IMAGE_NAME}" | grep "${IMAGE_TAG}"; then
+  if docker images --format "{{.Repository}}:{{.Tag}}" | grep "${IMAGE_NAME}:${IMAGE_TAG}"; then
     set -e
     loudecho "Assuming ${IMAGE_NAME}:${IMAGE_TAG} has been built and pushed"
   else
     set -e
     loudecho "Building and pushing test driver image to ${IMAGE_NAME}:${IMAGE_TAG}"
     aws ecr get-login-password --region "${REGION}" | docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}".dkr.ecr."${REGION}".amazonaws.com
-    docker build -t "${IMAGE_NAME}":"${IMAGE_TAG}" .
+    IMAGE=${IMAGE_NAME} TAG=${IMAGE_TAG} OS=linux ARCH=amd64 OSVERSION=amazon make image
+    docker tag "${IMAGE_NAME}":"${IMAGE_TAG}"-linux-amd64-amazon "${IMAGE_NAME}":"${IMAGE_TAG}"
     docker push "${IMAGE_NAME}":"${IMAGE_TAG}"
   fi
 }

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -42,7 +42,7 @@ REGION=${AWS_REGION:-us-west-2}
 ZONES=${AWS_AVAILABILITY_ZONES:-us-west-2a,us-west-2b,us-west-2c}
 FIRST_ZONE=$(echo "${ZONES}" | cut -d, -f1)
 NODE_COUNT=${NODE_COUNT:-3}
-INSTANCE_TYPE=${INSTANCE_TYPE:-c4.large}
+INSTANCE_TYPE=${INSTANCE_TYPE:-c5.large}
 
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 IMAGE_NAME=${IMAGE_NAME:-${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${DRIVER_NAME}}
@@ -50,16 +50,22 @@ IMAGE_TAG=${IMAGE_TAG:-${TEST_ID}}
 
 # kops: must include patch version (e.g. 1.19.1)
 # eksctl: mustn't include patch version (e.g. 1.19)
-K8S_VERSION=${K8S_VERSION:-1.20.6}
+K8S_VERSION=${K8S_VERSION:-1.20.8}
 
-KOPS_VERSION=${KOPS_VERSION:-1.20.0}
+KOPS_VERSION=${KOPS_VERSION:-1.21.0}
 KOPS_STATE_FILE=${KOPS_STATE_FILE:-s3://k8s-kops-csi-e2e}
 KOPS_PATCH_FILE=${KOPS_PATCH_FILE:-./hack/kops-patch.yaml}
 KOPS_PATCH_NODE_FILE=${KOPS_PATCH_NODE_FILE:-./hack/kops-patch-node.yaml}
 
+EKSCTL_VERSION=${EKSCTL_VERSION:-0.69.0}
 EKSCTL_PATCH_FILE=${EKSCTL_PATCH_FILE:-./hack/eksctl-patch.yaml}
+EKSCTL_ADMIN_ROLE=${EKSCTL_ADMIN_ROLE:-}
+# Creates a windows node group. The windows ami doesn't (yet) install csi-proxy
+# so that has to be done separately.
+WINDOWS=${WINDOWS:-"false"}
 
 HELM_VALUES_FILE=${HELM_VALUES_FILE:-./hack/values.yaml}
+HELM_EXTRA_FLAGS=${HELM_EXTRA_FLAGS:-}
 
 TEST_PATH=${TEST_PATH:-"./tests/e2e/..."}
 ARTIFACTS=${ARTIFACTS:-"${TEST_DIR}/artifacts"}
@@ -68,7 +74,8 @@ GINKGO_SKIP=${GINKGO_SKIP:-"\[Disruptive\]"}
 GINKGO_NODES=${GINKGO_NODES:-4}
 TEST_EXTRA_FLAGS=${TEST_EXTRA_FLAGS:-}
 
-EBS_SNAPSHOT_CRD=${EBS_SNAPSHOT_CRD:-"./deploy/kubernetes/cluster/crd_snapshotter.yaml"}
+EBS_INSTALL_SNAPSHOT=${EBS_INSTALL_SNAPSHOT:-"false"}
+EBS_INSTALL_SNAPSHOT_VERSION=${EBS_INSTALL_SNAPSHOT_VERSION:-"v4.1.1"}
 EBS_CHECK_MIGRATION=${EBS_CHECK_MIGRATION:-"false"}
 
 CLEAN=${CLEAN:-"true"}
@@ -82,8 +89,8 @@ if [[ "${CLUSTER_TYPE}" == "kops" ]]; then
   kops_install "${BIN_DIR}" "${KOPS_VERSION}"
   KOPS_BIN=${BIN_DIR}/kops
 elif [[ "${CLUSTER_TYPE}" == "eksctl" ]]; then
-  loudecho "Installing eksctl latest to ${BIN_DIR}"
-  eksctl_install "${BIN_DIR}"
+  loudecho "Installing eksctl ${EKSCTL_VERSION} to ${BIN_DIR}"
+  eksctl_install "${BIN_DIR}" "${EKSCTL_VERSION}"
   EKSCTL_BIN=${BIN_DIR}/eksctl
 else
   loudecho "${CLUSTER_TYPE} must be kops or eksctl!"
@@ -134,10 +141,21 @@ elif [[ "${CLUSTER_TYPE}" == "eksctl" ]]; then
     "$K8S_VERSION" \
     "$CLUSTER_FILE" \
     "$KUBECONFIG" \
-    "$EKSCTL_PATCH_FILE"
+    "$EKSCTL_PATCH_FILE" \
+    "$EKSCTL_ADMIN_ROLE" \
+    "$WINDOWS"
   if [[ $? -ne 0 ]]; then
     exit 1
   fi
+fi
+
+if [[ "${EBS_INSTALL_SNAPSHOT}" == true ]]; then
+  loudecho "Installing snapshot controller and CRDs"
+  kubectl apply --kubeconfig "${KUBECONFIG}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/"${EBS_INSTALL_SNAPSHOT_VERSION}"/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+  kubectl apply --kubeconfig "${KUBECONFIG}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/"${EBS_INSTALL_SNAPSHOT_VERSION}"/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+  kubectl apply --kubeconfig "${KUBECONFIG}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/"${EBS_INSTALL_SNAPSHOT_VERSION}"/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+  kubectl apply --kubeconfig "${KUBECONFIG}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/"${EBS_INSTALL_SNAPSHOT_VERSION}"/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+  kubectl apply --kubeconfig "${KUBECONFIG}" -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/"${EBS_INSTALL_SNAPSHOT_VERSION}"/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
 fi
 
 loudecho "Deploying driver"
@@ -150,19 +168,17 @@ HELM_ARGS=(upgrade --install "${DRIVER_NAME}"
   --wait
   --kubeconfig "${KUBECONFIG}"
   ./charts/"${DRIVER_NAME}")
-if test -f "$HELM_VALUES_FILE"; then
+if [[ -f "$HELM_VALUES_FILE" ]]; then
   HELM_ARGS+=(-f "${HELM_VALUES_FILE}")
+fi
+eval "EXPANDED_HELM_EXTRA_FLAGS=$HELM_EXTRA_FLAGS"
+if [[ -n "$EXPANDED_HELM_EXTRA_FLAGS" ]]; then
+  HELM_ARGS+=("${EXPANDED_HELM_EXTRA_FLAGS}")
 fi
 set -x
 "${HELM_BIN}" "${HELM_ARGS[@]}"
 set +x
 
-if [[ -r "${EBS_SNAPSHOT_CRD}" ]]; then
-  loudecho "Deploying snapshot CRD"
-  kubectl apply -f "$EBS_SNAPSHOT_CRD" \
-    --kubeconfig "${KUBECONFIG}"
-  # TODO deploy snapshot controller too instead of including in helm chart
-fi
 endSec=$(date +'%s')
 secondUsed=$(((endSec - startSec) / 1))
 # Set timeout threshold as 20 seconds for now, usually it takes less than 10s to startup


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** 

**What is this PR about? / Why do we need it?** https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/218 this shoudl make the build faster since we can build arm (target) binaries from a amd (build) node/host: https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images.

**What testing is done?** 
WIP: just sanity checking that the arm image built has an arm binary in it, and amd an amd.

REPO=x.dkr.ecr.us-west-2.amazonaws.com/eks/aws-fsx-csi-driver TAG=multiarchtest docker buildx build \
                                                           -t $REPO:$TAG \                                                           --platform=linux/arm64,linux/amd64 \
                                                           --progress plain \
                                                           --push .


sh-4.2# file /bin/aws-fsx-csi-driver 
/bin/aws-fsx-csi-driver: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, not stripped