### PR TITLE
Release 0.7.0 part 2/3: helm and kustomize

### DIFF
--- a/CHANGELOG-0.x.md
+++ b/CHANGELOG-0.x.md
@@ -6,6 +6,8 @@
 ### Misc.
 * Update Doc and Support Template ([#215](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/215), [@CandiedCode](https://github.com/CandiedCode))
 * Release 0.6.0 part 3/3: merge previous parts to master ([#216](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/216), [@wongma7](https://github.com/wongma7))
+* Bump ginkgo ([#220](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/220), [@wongma7](https://github.com/wongma7))
+* Use latest buildx github action and build target platform from build platform  ([#221](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/221), [@wongma7](https://github.com/wongma7))
 
 # v0.6.0
 

--- a/charts/aws-fsx-csi-driver/CHANGELOG.md
+++ b/charts/aws-fsx-csi-driver/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Helm chart
 
+# v1.3.0
+* Use driver 0.7.0
+
 # v1.2.0
 * Use driver 0.6.0
 * Add sidecar for storage scaling (external-resizer)

--- a/charts/aws-fsx-csi-driver/Chart.yaml
+++ b/charts/aws-fsx-csi-driver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "0.6.0"
+appVersion: "0.7.0"
 name: aws-fsx-csi-driver
 description: A Helm chart for AWS FSx for Lustre CSI Driver
-version: 1.2.0
+version: 1.3.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-fsx-csi-driver
 sources:

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: amazon/aws-fsx-csi-driver
-  tag: v0.6.0
+  tag: v0.7.0
   pullPolicy: IfNotPresent
 
 sidecars:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -31,7 +31,7 @@ spec:
           tolerationSeconds: 300
       containers:
         - name: fsx-plugin
-          image: amazon/aws-fsx-csi-driver:v0.6.0
+          image: amazon/aws-fsx-csi-driver:v0.7.0
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         - name: fsx-plugin
           securityContext:
             privileged: true
-          image: amazon/aws-fsx-csi-driver:v0.6.0
+          image: amazon/aws-fsx-csi-driver:v0.7.0
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -5,4 +5,4 @@ bases:
 images:
   - name: amazon/aws-fsx-csi-driver
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-fsx-csi-driver
-    newTag: v0.6.0
+    newTag: v0.7.0

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -4,4 +4,4 @@ bases:
   - ../../base
 images:
   - name: amazon/aws-fsx-csi-driver
-    newTag: v0.6.0
+    newTag: v0.7.0


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Neither

**What is this PR about? / Why do we need it?**
Part 2 bumps the helm chart version and updates kustomize to use v0.7.0 of the driver. Also updated the changelog to reflect PR's since part 1 of this release.

Following release process documented here: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/RELEASE.md 

**What testing is done?** 
Verified that dockerhub image is pullable and manifest indicates multiarch image.
Verified that ECR image is pullable and manifest indicates multiarch image.