### PR TITLE
Add make all-push rule

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -14,18 +14,24 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-      - name: Push to Dockerhub registry
+      - name: Set environment variables
         run: |
-          BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)
-          REPO=amazon/aws-fsx-csi-driver
-          if [ "$BRANCH" = "master" ]; then
-            TAG="latest"
+          REGISTRY_NAME=docker.io/amazon
+          BRANCH_OR_TAG=$(echo $GITHUB_REF | cut -d'/' -f3)
+          if [ "$BRANCH_OR_TAG" = "master" ]; then
+            GIT_TAG=$GITHUB_SHA
           else
-            TAG=$BRANCH
+            GIT_TAG=$BRANCH_OR_TAG
           fi
-          docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
-          docker buildx build \
-            -t $REPO:$TAG \
-            --platform=linux/arm64,linux/amd64 \
-            --progress plain \
-            --push .
+          echo "REGISTRY_NAME=$REGISTRY_NAME" >> $GITHUB_ENV
+          echo "GIT_TAG=$GIT_TAG" >> $GITHUB_ENV
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Push manifest list containing amazon linux based images to Docker Hub
+        run: |
+          export REGISTRY=$REGISTRY_NAME
+          export TAG=$GIT_TAG
+          make all-push

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,10 @@
 
 FROM --platform=$BUILDPLATFORM golang:1.16.8-stretch as builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-fsx-csi-driver
-
+COPY . .
 ARG TARGETOS
 ARG TARGETARCH
-RUN echo "TARGETOS:$TARGETOS, TARGETARCH:$TARGETARCH"
-RUN echo "I am running on $(uname -s)/$(uname -m)"
-
-COPY . .
-
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make aws-fsx-csi-driver
+RUN OS=$TARGETOS ARCH=$TARGETARCH make $TARGETOS/$TARGETARCH
 
 FROM amazonlinux:2 AS linux-amazon
 RUN yum update -y

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,10 @@ linux/$(ARCH): bin/aws-fsx-csi-driver
 bin/aws-fsx-csi-driver: | bin
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -ldflags ${LDFLAGS} -o bin/aws-fsx-csi-driver ./cmd/
 
+.PHONY: all
 all: all-image-docker
 
+.PHONY: all-push
 all-push:
 	docker buildx build \
 		--platform=$(PLATFORM) \
@@ -67,11 +69,13 @@ all-push:
 		.
 	touch $@
 
+.PHONY: all-image-docker
 all-image-docker: $(addprefix sub-image-docker-,$(ALL_OS_ARCH_OSVERSION_linux))
 
 sub-image-%:
 	$(MAKE) OUTPUT_TYPE=$(call word-hyphen,$*,1) OS=$(call word-hyphen,$*,2) ARCH=$(call word-hyphen,$*,3) OSVERSION=$(call word-hyphen,$*,4) image
 
+.PHONY: image
 image: .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION)
 .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION):
 	docker buildx build \
@@ -117,6 +121,7 @@ test-e2e:
 	GINKGO_SKIP="subPath.should.be.able.to.unmount.after.the.subpath.directory.is.deleted|\[Disruptive\]|\[Serial\]" \
 	./hack/e2e/run.sh
 
+.PHONY: generate-kustomize
 generate-kustomize: bin/helm
 	cd charts/aws-fsx-csi-driver && ../../bin/helm template kustomize . -s templates/csidriver.yaml > ../../deploy/kubernetes/base/csidriver.yaml
 	cd charts/aws-fsx-csi-driver && ../../bin/helm template kustomize . -s templates/node-daemonset.yaml > ../../deploy/kubernetes/base/node-daemonset.yaml


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** The make all-puish rule makes build procedure consistent with https://github.com/kubernetes-sigs/aws-ebs-csi-driver. I do NOT want to import the complicated low-level manifest manipulation from Makefile of https://github.com/kubernetes-sigs/aws-ebs-csi-driver because it is not necessary for building non-windows images. However the top-level make rules like all-push and variables like REGISTRY/TAG should be consistent.

**What testing is done?** 
