### PR TITLE
Parameter : perUnitStorageThroughput is mandatory for deploymentType PERSISTENT_1 and PERSISTENT_2

### DIFF
--- a/examples/kubernetes/dynamic_provisioning/README.md
+++ b/examples/kubernetes/dynamic_provisioning/README.md
@@ -13,13 +13,14 @@ parameters:
   subnetId: subnet-056da83524edbe641
   securityGroupIds: sg-086f61ea73388fb6b
   deploymentType: PERSISTENT_1
+  perUnitStorageThroughput: "200"
   storageType: HDD
 ```
 * subnetId - the subnet ID that the FSx for Lustre filesystem should be created inside.
 * securityGroupIds - a common separated list of security group IDs that should be attached to the filesystem
 * deploymentType (Optional) - FSx for Lustre supports three deployment types, SCRATCH_1, SCRATCH_2 and PERSISTENT_1. Default: SCRATCH_1.
 * kmsKeyId (Optional) - for deployment type PERSISTENT_1, customer can specify a KMS key to use.
-* perUnitStorageThroughput (Optional) - for deployment type PERSISTENT_1, customer can specify the storage throughput. Default: "200". Note that customer has to specify as a string here like "200" or "100" etc.
+* perUnitStorageThroughput (Optional) - for deployment type PERSISTENT_1, customer must specify the storage throughput. Note that customer has to specify as a string here like "200" or "100" etc.
 * storageType (Optional) - for deployment type PERSISTENT_1, customer can specify the storage type, either SSD or HDD. Default: "SSD"
 * driveCacheType (Required if storageType is "HDD") - for HDD PERSISTENT_1, specify the type of drive cache, either NONE or READ.
 * automaticBackupRetentionDays (Optional) - The number of days to retain automatic backups. The default is to retain backups for 7 days. Setting this value to 0 disables the creation of automatic backups. The maximum retention period for backups is 35 days

--- a/examples/kubernetes/dynamic_provisioning_s3/README.md
+++ b/examples/kubernetes/dynamic_provisioning_s3/README.md
@@ -25,7 +25,7 @@ parameters:
 * s3ExportPath(Optional) - S3 data repository you want to export new or modified files from persistent volume to S3.
 * deploymentType (Optional) - FSx for Lustre supports three deployment types, SCRATCH_1, SCRATCH_2 and PERSISTENT_1. Default: SCRATCH_1.
 * kmsKeyId (Optional) - for deployment type PERSISTENT_1, customer can specify a KMS key to use.
-* perUnitStorageThroughput (Optional) - for deployment type PERSISTENT_1, customer can specify the storage throughput. Default: "200". Note that customer has to specify as a string here like "200" or "100" etc.
+* perUnitStorageThroughput (Optional) - for deployment type PERSISTENT_1, customer must specify the storage throughput. Note that customer has to specify as a string here like "200" or "100" etc.
 * storageType (Optional) - for deployment type PERSISTENT_1, customer can specify the storage type, either SSD or HDD. Default: "SSD"
 * driveCacheType (Required if storageType is "HDD") - for HDD PERSISTENT_1, specify the type of drive cache, either NONE or READ.
 * dataCompressionType (Optional) - FSx for Lustre supports data compression via LZ4 algorithm. Compression is disabled when the value is set to NONE. The default value is NONE


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Document correction

**What is this PR about? / Why do we need it?**
Document is incorrect, following this document leads to below error : 

  Normal   ExternalProvisioning  10s               persistentvolume-controller                                                          waiting for a volume to be created, either by external provisioner "fsx.csi.aws.com" or manually created by system administrator
  Normal   Provisioning          2s (x4 over 10s)  fsx.csi.aws.com_ip-192-168-xxx-xx.ec2.internal_e83c96db-26db-48b4-8b13-f61544410907  External provisioner is provisioning volume for claim "default/fsx-claim"
  Warning  ProvisioningFailed    2s (x4 over 9s)   fsx.csi.aws.com_ip-192-168-xxx-xx.ec2.internal_e83c96db-26db-48b4-8b13-f61544410907  failed to provision volume with StorageClass "fsx-sc": rpc error: code = Internal desc = Could not create volume "pvc-4dfc8fe7-3348-4ceb-b02a-925cb4274c18": 
  CreateFileSystem failed: InvalidPerUnitStorageThroughput: The storage throughput (MB/s/TiB) value should be one of [50,100,200].

**What testing is done?** 
Successfully replicated and corrected 