### PR TITLE
Update owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- d-nishi
-- leakingtapan
 - justinsb
-- jsafrane
 - wongma7
-- ayberk
+- olemarkus
+- nckturner
+- khoang98


### PR DESCRIPTION
@olemarkus expressed interest in helping with this repository due to an need from his employer.  He has significant CNCF maintainer experience in kops, cloud-provider-aws, and others.  I'm also removing inactives and adding @khoang98 because she's a recent contributor on the FSx team at AWS.  I'm adding myself in case there is need for approvals and others aren't available, but I don't expect to contribute.  

- remove inactive
- add khoang98, olemarkus, myself

/cc @wongma7 @olemarkus @khoang98 
