### PR TITLE
Added templating for CSIDriver object configuration

### DIFF
--- a/charts/aws-fsx-csi-driver/CHANGELOG.md
+++ b/charts/aws-fsx-csi-driver/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Helm chart
 #v1.4.3
-* Added configurable options for csi object with sane defaults
+* Added option to configure `fsGroupPolicy` on the CSIDriver object. Adding such a configuration allows kubelet to change ownership of every file in the volume at mount time.
+Documentation on fsGroupPolicy can be found [here](https://kubernetes-csi.github.io/docs/support-fsgroup.html).
+
+**Side-note**: Setting fsGroupPolicy to `File` in for configurations that mount the disk on multiple nodes as the same time can lead to race-conditions and subsequently deadlocks, unless if **every** Pod mounting the volume has the same *securityContext* which includes the setting `fsGroupChangePolicy: "OnRootMismatch"`
 
 #v1.4.2
 * Use driver 0.8.2

--- a/charts/aws-fsx-csi-driver/CHANGELOG.md
+++ b/charts/aws-fsx-csi-driver/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Helm chart
+#v1.4.3
+* Added configurable options for csi object with sane defaults
+
 #v1.4.2
 * Use driver 0.8.2
 

--- a/charts/aws-fsx-csi-driver/Chart.yaml
+++ b/charts/aws-fsx-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.8.2"
 name: aws-fsx-csi-driver
 description: A Helm chart for AWS FSx for Lustre CSI Driver
-version: 1.4.2
+version: 1.4.3
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-fsx-csi-driver
 sources:

--- a/charts/aws-fsx-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-fsx-csi-driver/templates/csidriver.yaml
@@ -3,12 +3,5 @@ kind: CSIDriver
 metadata:
   name: fsx.csi.aws.com
 spec:
-  attachRequired: {{ .Values.csidriver.attachRequired }}
+  attachRequired: false
   fsGroupPolicy: {{ .Values.csidriver.fsGroupPolicy }}
-  podInfoOnMount: {{ .Values.csidriver.podInfoOnMount }}
-  requiresRepublish: {{ .Values.csidriver.requiresRepublish }}
-  storageCapacity: {{ .Values.csidriver.storageCapacity }}
-  volumeLifecycleModes: 
-  {{- range .Values.csidriver.volumeLifecycleModes }}
-  - {{.}}
-  {{- end }}

--- a/charts/aws-fsx-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-fsx-csi-driver/templates/csidriver.yaml
@@ -3,4 +3,12 @@ kind: CSIDriver
 metadata:
   name: fsx.csi.aws.com
 spec:
-  attachRequired: false
+  attachRequired: {{ .Values.csidriver.attachRequired }}
+  fsGroupPolicy: {{ .Values.csidriver.fsGroupPolicy }}
+  podInfoOnMount: {{ .Values.csidriver.podInfoOnMount }}
+  requiresRepublish: {{ .Values.csidriver.requiresRepublish }}
+  storageCapacity: {{ .Values.csidriver.storageCapacity }}
+  volumeLifecycleModes: 
+  {{- range .Values.csidriver.volumeLifecycleModes }}
+  - {{.}}
+  {{- end }}

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -7,6 +7,15 @@ image:
   tag: v0.8.2
   pullPolicy: IfNotPresent
 
+csidriver:
+  attachRequired: false
+  fsGroupPolicy: ReadWriteOnceWithFSType
+  podInfoOnMount: false
+  requiresRepublish: false
+  storageCapacity: false
+  volumeLifecycleModes:
+  - Persistent
+
 sidecars:
   livenessProbe:
     image:

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -8,13 +8,7 @@ image:
   pullPolicy: IfNotPresent
 
 csidriver:
-  attachRequired: false
   fsGroupPolicy: ReadWriteOnceWithFSType
-  podInfoOnMount: false
-  requiresRepublish: false
-  storageCapacity: false
-  volumeLifecycleModes:
-  - Persistent
 
 sidecars:
   livenessProbe:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New feature: Adding templating for configuring the CSIDriver object.

**What is this PR about? / Why do we need it?**

To run pods with non-root users and to avoid usage of initContainers that chown the volume, we want to be able to let k8s traverse the filesystem and change the ownership for us. This currently cannot be done as the CSIDriver object always sets defaults, specifically `fsGroupPolicy`

**What testing is done?** 

Tested by applying the new chart version to a cluster running k8s v 1.23.12. Was able to change `fsGroupPolicy` to `File`, allowing non-root pods to have read/write access to the provisioned volume
