### PR TITLE
Check if volume is mounted before unmounting

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -129,6 +129,13 @@ func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublish
 		return nil, status.Error(codes.InvalidArgument, "Target path not provided")
 	}
 
+	// Check if the target is mounted before unmounting
+	notMnt, _ := d.mounter.IsLikelyNotMountPoint(target)
+	if notMnt {
+		klog.V(5).Infof("NodeUnpublishVolume: target path %s not mounted, skipping unmount", target)
+		return &csi.NodeUnpublishVolumeResponse{}, nil
+	}
+
 	klog.V(5).Infof("NodeUnpublishVolume: unmounting %s", target)
 	err := d.mounter.Unmount(target)
 	if err != nil {

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -423,7 +423,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 					VolumeId:   "volumeId",
 					TargetPath: targetPath,
 				}
-				
+
 				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(targetPath)).Return(false, nil)
 				mockMounter.EXPECT().Unmount(gomock.Eq(targetPath)).Return(nil)
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix

**What is this PR about? / Why do we need it?**
We don't check if volume is mounted before unmounting. This causes pods to be stuck in terminating if we ever get into a situation where pod is already unmounted before trying to terminate pod. 

**What testing is done?** 
To reproduce:
- Create pod
- Unmount volume from node
- Try and delete pod

Reproduced locally and added a unit test here as well.
