### PR TITLE
Update import path to match the go module name

### DIFF
--- a/hack/update-gomock
+++ b/hack/update-gomock
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-IMPORT_PATH=github.com/kubernetes-sigs/aws-fsx-csi-driver
+IMPORT_PATH=sigs.k8s.io/aws-fsx-csi-driver
 mockgen -package=mocks -destination=./pkg/driver/mocks/mock_mount.go --build_flags=--mod=mod ${IMPORT_PATH}/pkg/driver Mounter
 mockgen -package=mocks -destination=./pkg/cloud/mocks/mock_ec2metadata.go --build_flags=--mod=mod ${IMPORT_PATH}/pkg/cloud EC2Metadata
 mockgen -package=mocks -destination=./pkg/cloud/mocks/mock_fsx.go --build_flags=--mod=mod ${IMPORT_PATH}/pkg/cloud FSx

--- a/pkg/driver/mocks/mock_mount.go
+++ b/pkg/driver/mocks/mock_mount.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	mount_utils "k8s.io/mount-utils"
+	mount "k8s.io/mount-utils"
 )
 
 // MockMounter is a mock of Mounter interface.
@@ -79,10 +79,10 @@ func (mr *MockMounterMockRecorder) IsLikelyNotMountPoint(arg0 interface{}) *gomo
 }
 
 // List mocks base method.
-func (m *MockMounter) List() ([]mount_utils.MountPoint, error) {
+func (m *MockMounter) List() ([]mount.MountPoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List")
-	ret0, _ := ret[0].([]mount_utils.MountPoint)
+	ret0, _ := ret[0].([]mount.MountPoint)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
/kind bug

**What is this PR about? / Why do we need it?**
When the module name changed, this script was not updated so mock generation fails.

**What testing is done?** 
Not really applicable