### PR TITLE
Bump sidecar versions

### DIFF
--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -14,25 +14,25 @@ sidecars:
   livenessProbe:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-      tag: v2.2.0-eks-1-18-13
+      tag: v2.8.0-eks-1-23-8
       pullPolicy: IfNotPresent
     resources: {}
   nodeDriverRegistrar:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-      tag: v2.1.0-eks-1-18-13
+      tag: v2.6.1-eks-1-23-8
       pullPolicy: IfNotPresent
     resources: {}
   provisioner:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-      tag: v2.1.1-eks-1-18-13
+      tag: v3.3.0-eks-1-23-8
       pullPolicy: IfNotPresent
     resources: {}
   resizer:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
-      tag: v1.1.0-eks-1-18-13
+      tag: v1.6.0-eks-1-23-8
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -66,7 +66,7 @@ spec:
             periodSeconds: 2
             failureThreshold: 5
         - name: csi-provisioner
-          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v2.1.1-eks-1-18-13
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.3.0-eks-1-23-8
           args:
             - --csi-address=$(ADDRESS)
             - --timeout=5m
@@ -79,7 +79,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.1.0-eks-1-18-13
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.6.0-eks-1-23-8
           args:
             - --csi-address=$(ADDRESS)
             - --leader-election=true
@@ -91,7 +91,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-18-13
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.8.0-eks-1-23-8
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9910


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bumps sidecars to a more recent version

**What is this PR about? / Why do we need it?**
I'm bumping the sidecar images to version 1.23 to get the conversation started on updating the images used. 1.18 has been out of support for some time. I noticed 1.18 was almost out of support when it was updated last so you may not want to go all the way to 1.23. 

We could also go up to 1.24, but the best would be to use the correct version based on the k8s version being used. Adding  switching logic based on version in helm is easy enough, but first we'd need to rethink the approach of building a single version for all clusters, and move to building different versions for each version of K8s supported by EKS. Short of that, this PR addresses several security and support issues from running old versions. 

**What testing is done?** 
No testing yet 