### PR TITLE
Update container-image workflow to publish image to ECR public

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -1,11 +1,15 @@
 name: Container Images
 
 on: push
+env:
+  REGION : "us-east-1"
 jobs:
   build:
     # this is to prevent the job to run at forked projects
     if: github.repository == 'kubernetes-sigs/aws-fsx-csi-driver'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -14,24 +18,28 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-      - name: Set environment variables
+            - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          role-to-assume: arn:aws:iam::664215443545:role/LustreCSIDriverImagePublisherRole
+          aws-region: ${{ env.REGION }}
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: public
+      - name: Build, tag, and push docker image to Amazon ECR Public Repository
+        env:
+          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          REGISTRY_ALIAS: fsx-csi-driver
+          REPOSITORY: aws-fsx-csi-driver
         run: |
-          REGISTRY_NAME=docker.io/amazon
           BRANCH_OR_TAG=$(echo $GITHUB_REF | cut -d'/' -f3)
           if [ "$BRANCH_OR_TAG" = "master" ]; then
             GIT_TAG=$GITHUB_SHA
           else
             GIT_TAG=$BRANCH_OR_TAG
           fi
-          echo "REGISTRY_NAME=$REGISTRY_NAME" >> $GITHUB_ENV
-          echo "GIT_TAG=$GIT_TAG" >> $GITHUB_ENV
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Push manifest list containing amazon linux based images to Docker Hub
-        run: |
-          export REGISTRY=$REGISTRY_NAME
+          export REGISTRY=$REGISTRY/$REGISTRY_ALIAS
           export TAG=$GIT_TAG
           make all-push

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: amazon/aws-fsx-csi-driver
+  repository: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver
   tag: v0.9.0
   pullPolicy: IfNotPresent
 

--- a/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../bases
+images:
+  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-fsx-csi-driver
+    newName: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -1,7 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../../base
-images:
-  - name: amazon/aws-fsx-csi-driver
-    newTag: v0.9.0
+resources:
+  - ./ecr-public


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New Feature

**What is this PR about? / Why do we need it?**
As per a recent AWS wide campaign, we want to move away from dockerhub and use AWS ECR public repository to host aws-fsx-csi-driver docker images. ECR public provides many advantages over dockerhub wherein customers can request images at higher rates without getting throttled. Amazon ECR will also provide additional security for the images and would provide a better user experience for the customer.

**What testing is done?** 
The testing was conducted on a forked branch. Workflow executed on forked branch: https://github.com/siddharthsalot/aws-fsx-csi-driver/actions/runs/3498761218/jobs/5859534269
ECR public gallery created from Dev account: https://gallery.ecr.aws/g5x7u5l2/aws-fsx-csi-driver

**Note**:
* Originally this change was published as part of PR: https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/278. The original PR was discarded and I created a new one.
* The chart version and the image version need not be updated because this is just a workflow change and does not introduce any new changes to the docker image itself.
* No helm-chart tests were executed as part of testing.
