### PR TITLE
Follow up kustomize manifests

### DIFF
--- a/deploy/kubernetes/base/csidriver.yaml
+++ b/deploy/kubernetes/base/csidriver.yaml
@@ -6,3 +6,4 @@ metadata:
   name: fsx.csi.aws.com
 spec:
   attachRequired: false
+  fsGroupPolicy: ReadWriteOnceWithFSType

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -59,7 +59,7 @@ spec:
             periodSeconds: 2
             failureThreshold: 5
         - name: node-driver-registrar
-          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0-eks-1-18-13
+          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.6.1-eks-1-23-8
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -79,7 +79,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-18-13
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.8.0-eks-1-23-8
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Only update kustomize manifests.

**What is this PR about? / Why do we need it?**

Update kustomize manifests to following up
  - CSIDriver #262
  - Sidecars of DaemonSet #283

**What testing is done?** 

Run `kustomize build deploy/kubernetes/overlays/stable` then checked updates were applied.
