### PR TITLE
 Update container-image workflow to publish image to ECR public

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -1,11 +1,15 @@
 name: Container Images
 
 on: push
+env:
+  REGION : "us-east-1"
 jobs:
   build:
     # this is to prevent the job to run at forked projects
     if: github.repository == 'kubernetes-sigs/aws-fsx-csi-driver'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -14,24 +18,28 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-      - name: Set environment variables
+            - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          role-to-assume: arn:aws:iam::664215443545:role/LustreCSIDriverImagePublisherRole
+          aws-region: ${{ env.REGION }}
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: public
+      - name: Build, tag, and push docker image to Amazon ECR Public Repository
+        env:
+          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          REGISTRY_ALIAS: fsx-csi-driver
+          REPOSITORY: aws-fsx-csi-driver
         run: |
-          REGISTRY_NAME=docker.io/amazon
           BRANCH_OR_TAG=$(echo $GITHUB_REF | cut -d'/' -f3)
           if [ "$BRANCH_OR_TAG" = "master" ]; then
             GIT_TAG=$GITHUB_SHA
           else
             GIT_TAG=$BRANCH_OR_TAG
           fi
-          echo "REGISTRY_NAME=$REGISTRY_NAME" >> $GITHUB_ENV
-          echo "GIT_TAG=$GIT_TAG" >> $GITHUB_ENV
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Push manifest list containing amazon linux based images to Docker Hub
-        run: |
-          export REGISTRY=$REGISTRY_NAME
+          export REGISTRY=$REGISTRY/$REGISTRY_ALIAS
           export TAG=$GIT_TAG
           make all-push

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: amazon/aws-fsx-csi-driver
+  repository: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver
   tag: v0.9.0
   pullPolicy: IfNotPresent
 

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -31,7 +31,7 @@ spec:
           tolerationSeconds: 300
       containers:
         - name: fsx-plugin
-          image: amazon/aws-fsx-csi-driver:v0.9.0
+          image: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.9.0
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         - name: fsx-plugin
           securityContext:
             privileged: true
-          image: amazon/aws-fsx-csi-driver:v0.9.0
+          image: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.9.0
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
@@ -1,7 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-  - ../../bases
-images:
-  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-fsx-csi-driver
-    newName: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver
+  - ../../../base

--- a/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../bases
+images:
+  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-fsx-csi-driver
+    newName: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 bases:
   - ../../../base
 images:
-  - name: amazon/aws-fsx-csi-driver
+  - name: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-fsx-csi-driver
     newTag: v0.9.0

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -1,7 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../../base
-images:
-  - name: amazon/aws-fsx-csi-driver
-    newTag: v0.9.0
+resources:
+  - ./ecr-public

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,20 +55,20 @@ The following sections are Kubernetes-specific. If you are a Kubernetes user, us
 ### Container Images
 | FSx CSI Driver Version | Image                            |
 |------------------------|----------------------------------|
-| master branch          | amazon/aws-fsx-csi-driver:latest |
-| v0.9.0                 | amazon/aws-fsx-csi-driver:v0.9.0 |
-| v0.8.3                 | amazon/aws-fsx-csi-driver:v0.8.3 |
-| v0.8.2                 | amazon/aws-fsx-csi-driver:v0.8.2 |
-| v0.8.1                 | amazon/aws-fsx-csi-driver:v0.8.1 |
-| v0.8.0                 | amazon/aws-fsx-csi-driver:v0.8.0 |
-| v0.7.1                 | amazon/aws-fsx-csi-driver:v0.7.1 |
-| v0.7.0                 | amazon/aws-fsx-csi-driver:v0.7.0 |
-| v0.6.0                 | amazon/aws-fsx-csi-driver:v0.6.0 |
-| v0.5.0                 | amazon/aws-fsx-csi-driver:v0.5.0 |
-| v0.4.0                 | amazon/aws-fsx-csi-driver:v0.4.0 |
-| v0.3.0                 | amazon/aws-fsx-csi-driver:v0.3.0 |
-| v0.2.0                 | amazon/aws-fsx-csi-driver:v0.2.0 |
-| v0.1.0                 | amazon/aws-fsx-csi-driver:v0.1.0 |
+| master branch          | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:latest |
+| v0.9.0                 | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.9.0 |
+| v0.8.3                 | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.8.3 |
+| v0.8.2                 | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.8.2 |
+| v0.8.1                 | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.8.1 |
+| v0.8.0                 | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.8.0 |
+| v0.7.1                 | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.7.1 |
+| v0.7.0                 | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.7.0 |
+| v0.6.0                 | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.6.0 |
+| v0.5.0                 | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.5.0 |
+| v0.4.0                 | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.4.0 |
+| v0.3.0                 | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.3.0 |
+| v0.2.0                 | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.2.0 |
+| v0.1.0                 | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.1.0 |
 
 ### Features
 * Static provisioning - FSx for Lustre file system needs to be created manually first, then it could be mounted inside container as a volume using the Driver.
@@ -134,6 +134,10 @@ kubectl apply -f secret.yaml
 #### Deploy driver
 ```sh
 kubectl apply -k "github.com/kubernetes-sigs/aws-fsx-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-0.9"
+# Alternatively,, to pull from
+# public ECR (public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver) instead of
+# private ECR (602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-fsx-csi-driver):
+kubectl apply -k "github.com/kubernetes-sigs/aws-fsx-csi-driver/deploy/kubernetes/overlays/stable/ecr-public?ref=release-0.9"
 ```
 
 Alternatively, you could also install the driver using helm:

--- a/examples/kubernetes/max_cache_tuning/README.md
+++ b/examples/kubernetes/max_cache_tuning/README.md
@@ -10,7 +10,7 @@ metadata:
 spec:
   initContainers:
   - name: set-lustre-cache
-    image: amazon/aws-fsx-csi-driver:latest
+    image: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.9.0
     securityContext:
       privileged: true
     command: ["/sbin/lctl"]

--- a/examples/kubernetes/max_cache_tuning/specs/pod.yaml
+++ b/examples/kubernetes/max_cache_tuning/specs/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   initContainers:
   - name: set-lustre-cache
-    image: amazon/aws-fsx-csi-driver:latest
+    image: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.9.0
     securityContext:
       privileged: true
     command: ["/sbin/lctl"]


### PR DESCRIPTION
https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/285

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

**What testing is done?** 
When using stable/ecr-public or stable overlay, public ECR images are used. 
```
$ k apply -k ./deploy/kubernetes/overlays/stable/ecr-public # OR k apply -k ./deploy/kubernetes/overlays/stable/
$ k get po -n kube-system -l  app.kubernetes.io/name=aws-fsx-csi-driver
NAME                                 READY   STATUS    RESTARTS   AGE
fsx-csi-controller-8c846c444-5bbgm   4/4     Running   0          7s
fsx-csi-controller-8c846c444-6xchg   4/4     Running   0          5s
fsx-csi-node-9dn6j                   3/3     Running   0          4s
fsx-csi-node-f2rsg                   3/3     Running   0          6s
fsx-csi-node-zc5wp                   3/3     Running   0          2s
$ k get po -n kube-system -l app.kubernetes.io/name=aws-fsx-csi-driver -o jsonpath="{.items[*].spec.containers[0].image}"
public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.9.0 public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.9.0 public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.9.0 public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.9.0 public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.9.0
```
When using stable/ecr overlay, private ECR images are used
```
$ k apply -k ./deploy/kubernetes/overlays/stable/ecr
$ k get po -n kube-system -l app.kubernetes.io/name=aws-fsx-csi-driver
NAME                                  READY   STATUS    RESTARTS   AGE
fsx-csi-controller-756766bf4f-gttk9   4/4     Running   0          14s
fsx-csi-controller-756766bf4f-zmmf9   4/4     Running   0          12s
fsx-csi-node-6bsfb                    3/3     Running   0          13s
fsx-csi-node-bcm2c                    3/3     Running   0          11s
fsx-csi-node-fbqd2                    3/3     Running   0          9s
$ k get po -n kube-system -l app.kubernetes.io/name=aws-fsx-csi-driver -o jsonpath="{.items[*].spec.containers[0].image}"
602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-fsx-csi-driver:v0.9.0 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-fsx-csi-driver:v0.9.0 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-fsx-csi-driver:v0.9.0 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-fsx-csi-driver:v0.9.0 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-fsx-csi-driver:v0.9.0
```
