### PR TITLE
Have CSI driver use 2.12 Lustre client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN OS=$TARGETOS ARCH=$TARGETARCH make $TARGETOS/$TARGETARCH
 FROM amazonlinux:2 AS linux-amazon
 RUN yum update -y
 RUN yum install util-linux libyaml -y \
-    && amazon-linux-extras install -y lustre2.10
+    && amazon-linux-extras install -y lustre
     
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-fsx-csi-driver/bin/aws-fsx-csi-driver /bin/aws-fsx-csi-driver
 COPY THIRD-PARTY /


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
update client
**What is this PR about? / Why do we need it?**
This PR moves the csi driver to use the 2.12 lustre client
**What testing is done?** 
