### PR TITLE
Bump CSI sidecar versions to track EKS Distro release v1-23-eks-12

### DIFF
--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -14,25 +14,25 @@ sidecars:
   livenessProbe:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-      tag: v2.8.0-eks-1-23-8
+      tag: v2.9.0-eks-1-23-12
       pullPolicy: IfNotPresent
     resources: {}
   nodeDriverRegistrar:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-      tag: v2.6.1-eks-1-23-8
+      tag: v2.7.0-eks-1-23-12
       pullPolicy: IfNotPresent
     resources: {}
   provisioner:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-      tag: v3.3.0-eks-1-23-8
+      tag: v3.4.0-eks-1-23-12
       pullPolicy: IfNotPresent
     resources: {}
   resizer:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
-      tag: v1.6.0-eks-1-23-8
+      tag: v1.7.0-eks-1-23-12
       pullPolicy: IfNotPresent
     resources: {}
 

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -66,7 +66,7 @@ spec:
             periodSeconds: 2
             failureThreshold: 5
         - name: csi-provisioner
-          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.3.0-eks-1-23-8
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.4.0-eks-1-23-12
           args:
             - --csi-address=$(ADDRESS)
             - --timeout=5m
@@ -79,7 +79,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.6.0-eks-1-23-8
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.7.0-eks-1-23-12
           args:
             - --csi-address=$(ADDRESS)
             - --leader-election=true
@@ -91,7 +91,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.8.0-eks-1-23-8
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.9.0-eks-1-23-12
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9910

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -59,7 +59,7 @@ spec:
             periodSeconds: 2
             failureThreshold: 5
         - name: node-driver-registrar
-          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0-eks-1-18-13
+          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.7.0-eks-1-23-12
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -79,7 +79,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.2.0-eks-1-18-13
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.9.0-eks-1-23-12
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

Bump the CSI sidecar image tags to track the updated versions from [the latest EKS Distro 1.23 release](https://distro.eks.amazonaws.com/releases/1-23/12/). See https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/283. 

**What testing is done?** 
