### PR TITLE
Update Makefile to have ecr as registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ GOPATH=$(shell go env GOPATH)
 GOOS=$(shell go env GOOS)
 GOBIN=$(shell pwd)/bin
 
-REGISTRY?=amazon
+REGISTRY?=public.ecr.aws
 IMAGE?=$(REGISTRY)/aws-fsx-csi-driver
 TAG?=$(GIT_COMMIT)
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
part of move to publishing to ecr
**What is this PR about? / Why do we need it?**
best practice to update makefile to point to the public ecr
**What testing is done?** 
