### PR TITLE
Support controller pod annotations in helm chart

### DIFF
--- a/charts/aws-fsx-csi-driver/CHANGELOG.md
+++ b/charts/aws-fsx-csi-driver/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Helm chart
 
+# v1.5.1
+* Support controller annotations in helm chart
+
 # v1.5.0
 * Use driver 0.9.0
 

--- a/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
@@ -12,6 +12,10 @@ spec:
       {{- include "aws-fsx-csi-driver.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.controller.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: fsx-csi-controller
         {{- include "aws-fsx-csi-driver.labels" . | nindent 8 }}

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -48,6 +48,7 @@ controller:
     name: fsx-csi-controller-sa
     annotations: {}
   tolerations: []
+  podAnnotations: {}
 
 node:
   nodeSelector: {}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix for https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/299

**What is this PR about? / Why do we need it?**

Able to define controller pod annotations in helm chart. Use case - authorize to AWS via IAM role instead credentials.

**What testing is done?** 
No testing
