### PR TITLE
add support for node pod annotations

### DIFF
--- a/charts/aws-fsx-csi-driver/CHANGELOG.md
+++ b/charts/aws-fsx-csi-driver/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Helm chart
 
 # v1.5.1
-* Support controller annotations in helm chart
+* Support controller pod annotations in helm chart
+* Support node pod annotations in helm chart
 
 # v1.5.0
 * Use driver 0.9.0

--- a/charts/aws-fsx-csi-driver/Chart.yaml
+++ b/charts/aws-fsx-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.9.0"
 name: aws-fsx-csi-driver
 description: A Helm chart for AWS FSx for Lustre CSI Driver
-version: 1.5.0
+version: 1.5.1
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-fsx-csi-driver
 sources:

--- a/charts/aws-fsx-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-fsx-csi-driver/templates/node-daemonset.yaml
@@ -11,6 +11,10 @@ spec:
       {{- include "aws-fsx-csi-driver.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.node.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: fsx-csi-node
         {{- include "aws-fsx-csi-driver.labels" . | nindent 8 }}

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -70,6 +70,7 @@ node:
     annotations: {}
   tolerateAllTaints: false
   tolerations: []
+  podAnnotations: {}
 
 nameOverride: ""
 fullnameOverride: ""

--- a/deploy/kubernetes/base/csidriver.yaml
+++ b/deploy/kubernetes/base/csidriver.yaml
@@ -6,3 +6,4 @@ metadata:
   name: fsx.csi.aws.com
 spec:
   attachRequired: false
+  fsGroupPolicy: ReadWriteOnceWithFSType


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Adding feature
**What is this PR about? / Why do we need it?**
This enables users to add podAnnotations to their nodes. This change is similar to the one here: https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/301 with the addition of releasing a new helm chart. podAnnotations are also helpful for cases like this: https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/253 where a pod annotation is needed to change default behavior
**What testing is done?** 
`helm install test charts/aws-fsx-csi-driver --namespace kube-system --set node.podAnnotations."key"="value"` and confirmed that annotation appeared on node pods
