### PR TITLE
Parameterise tolerations and securityContext

### DIFF
--- a/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
@@ -35,14 +35,22 @@ spec:
       serviceAccountName: {{ .Values.controller.serviceAccount.name }}
       priorityClassName: system-cluster-critical
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - operator: Exists
-          effect: NoExecute
-          tolerationSeconds: 300
         {{- with .Values.controller.tolerations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- if .Values.controller.topologySpreadConstraints }}
+      {{- $tscLabelSelector := dict "labelSelector" ( dict "matchLabels" ( dict "app" "fsx-csi-controller" ) ) }}
+      {{- $constraints := list }}
+      {{- range .Values.controller.topologySpreadConstraints }}
+        {{- $constraints = mustAppend $constraints (mergeOverwrite . $tscLabelSelector) }}
+      {{- end }}
+      topologySpreadConstraints:
+        {{- $constraints | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: fsx-plugin
           image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}

--- a/charts/aws-fsx-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-fsx-csi-driver/templates/node-daemonset.yaml
@@ -41,15 +41,14 @@ spec:
         {{- if .Values.node.tolerateAllTaints }}
         - operator: Exists
         {{- else }}
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - operator: Exists
-          effect: NoExecute
-          tolerationSeconds: 300
-        {{- end }}
         {{- with .Values.node.tolerations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- end }}
+      {{- with .Values.node.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: fsx-plugin
           securityContext:

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -47,7 +47,30 @@ controller:
     #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/fsx-csi-role
     name: fsx-csi-controller-sa
     annotations: {}
-  tolerations: []
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+    - operator: Exists
+      effect: NoExecute
+      tolerationSeconds: 300
+  # TSCs without the label selector stanza
+  #
+  # Example:
+  #
+  # topologySpreadConstraints:
+  #  - maxSkew: 1
+  #    topologyKey: topology.kubernetes.io/zone
+  #    whenUnsatisfiable: ScheduleAnyway
+  #  - maxSkew: 1
+  #    topologyKey: kubernetes.io/hostname
+  #    whenUnsatisfiable: ScheduleAnyway
+  topologySpreadConstraints: []
+  # securityContext on the controller pod
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
   podAnnotations: {}
 
 node:
@@ -69,7 +92,18 @@ node:
     name: fsx-csi-node-sa
     annotations: {}
   tolerateAllTaints: false
-  tolerations: []
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+    - operator: Exists
+      effect: NoExecute
+      tolerationSeconds: 300
+  # securityContext on the controller pod
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
   podAnnotations: {}
 
 nameOverride: ""

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -26,9 +26,14 @@ spec:
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
-        - operator: Exists
-          effect: NoExecute
+        - effect: NoExecute
+          operator: Exists
           tolerationSeconds: 300
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
         - name: fsx-plugin
           image: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.9.0

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -26,9 +26,14 @@ spec:
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
-        - operator: Exists
-          effect: NoExecute
+        - effect: NoExecute
+          operator: Exists
           tolerationSeconds: 300
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
         - name: fsx-plugin
           securityContext:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Better control of `tolerations` is required when all nodes in a cluster have taints with effect `NoExecute`.
Fixes https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/305

**What is this PR about? / Why do we need it?**

This PR gives better control over `tolerations` so they can be entirely replaced with custom ones.
The same level of customisation is applied to `securityContext`.

Note that this follows the same conventions as `aws-ebs-csi-driver`
Controller: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/templates/controller.yaml#L43
Daemonset: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/templates/node.yaml#L39

**What testing is done?** 
