### PR TITLE
use minimal base csi driver image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2019 The Kubernetes Authors.
+# Copyright 2023 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,11 +19,23 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN OS=$TARGETOS ARCH=$TARGETARCH make $TARGETOS/$TARGETARCH
 
-FROM amazonlinux:2 AS linux-amazon
-RUN yum update -y
-RUN yum install util-linux libyaml -y \
-    && amazon-linux-extras install -y lustre
-    
+# https://github.com/aws/eks-distro-build-tooling/blob/main/eks-distro-base/Dockerfile.minimal-base-csi-ebs#L36
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs-builder:latest-al2 as rpm-installer
+
+# shallow install systemd and the kernel which are not needed in the final container image
+# since lustre is not run as a systemd service and the kernel module is node loaded via the container
+# to avoid pulling in a large tree of unnecessary dependencies
+RUN set -x && \
+    enable_extra lustre && \
+    clean_install "kernel systemd" true true && \
+    clean_install lustre-client && \
+    remove_package "kernel systemd" true && \
+    cleanup "fsx-csi"
+
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest-al2 AS linux-amazon
+
+COPY --from=rpm-installer /newroot /
+
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-fsx-csi-driver/bin/aws-fsx-csi-driver /bin/aws-fsx-csi-driver
 COPY THIRD-PARTY /
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2019 The Kubernetes Authors.
+# Copyright 2023 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -58,20 +58,22 @@ bin/aws-fsx-csi-driver: | bin
 .PHONY: all
 all: all-image-docker
 
+# Builds all images and pushes them
 .PHONY: all-push
-all-push:
-	docker buildx build \
-		--no-cache-filter=linux-amazon \
-		--platform=$(PLATFORM) \
-		--progress=plain \
-		--target=$(OS)-$(OSVERSION) \
-		--output=type=registry \
-		-t=$(IMAGE):$(TAG) \
-		.
-	touch $@
+all-push: create-manifest-and-images
+	docker manifest push --purge $(IMAGE):$(TAG)
+
+.PHONY: create-manifest-and-images
+create-manifest-and-images: all-image-registry
+# sed expression:
+# LHS: match 0 or more not space characters
+# RHS: replace with $(IMAGE):$(TAG)-& where & is what was matched on LHS
+	docker manifest create --amend $(IMAGE):$(TAG) $(shell echo $(ALL_OS_ARCH_OSVERSION) | sed -e "s~[^ ]*~$(IMAGE):$(TAG)\-&~g")
 
 .PHONY: all-image-docker
 all-image-docker: $(addprefix sub-image-docker-,$(ALL_OS_ARCH_OSVERSION_linux))
+.PHONY: all-image-registry
+all-image-registry: $(addprefix sub-image-registry-,$(ALL_OS_ARCH_OSVERSION))
 
 sub-image-%:
 	$(MAKE) OUTPUT_TYPE=$(call word-hyphen,$*,1) OS=$(call word-hyphen,$*,2) ARCH=$(call word-hyphen,$*,3) OSVERSION=$(call word-hyphen,$*,4) image
@@ -80,12 +82,13 @@ sub-image-%:
 image: .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION)
 .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION):
 	docker buildx build \
-		--no-cache-filter=linux-amazon \
 		--platform=$(OS)/$(ARCH) \
 		--progress=plain \
 		--target=$(OS)-$(OSVERSION) \
 		--output=type=$(OUTPUT_TYPE) \
 		-t=$(IMAGE):$(TAG)-$(OS)-$(ARCH)-$(OSVERSION) \
+		--build-arg=GOPROXY=$(GOPROXY) \
+		--build-arg=VERSION=$(VERSION) \
 		.
 	touch $@
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
N/A
**What is this PR about? / Why do we need it?**
- Use a minimal base image for the csi driver to reduce CVEs and reduce image size by 80% (according to our testing)
- Makes a change to our Makefile so now images are tagged/labeled with architecture prefixes rather than being <untagged>
**What testing is done?** 
- manually tested dynamic provisioning and mounting
- e2e tests

These changes are based off of the ebs csi driver [Makefile](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/Makefile) and [Dockerfile](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/Dockerfile)