### PR TITLE
Remove ErrFsExistsDiffSize error on incompatible parameter

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -235,9 +235,6 @@ func (c *cloud) CreateFileSystem(ctx context.Context, volumeName string, fileSys
 
 	output, err := c.fsx.CreateFileSystemWithContext(ctx, input)
 	if err != nil {
-		if isIncompatibleParameter(err) {
-			return nil, ErrFsExistsDiffSize
-		}
 		return nil, fmt.Errorf("CreateFileSystem failed: %v", err)
 	}
 
@@ -427,15 +424,6 @@ func (c *cloud) getUpdateResizeAdministrativeAction(ctx context.Context, fileSys
 func isFileSystemNotFound(err error) bool {
 	if awsErr, ok := err.(awserr.Error); ok {
 		if awsErr.Code() == fsx.ErrCodeFileSystemNotFound {
-			return true
-		}
-	}
-	return false
-}
-
-func isIncompatibleParameter(err error) bool {
-	if awsErr, ok := err.(awserr.Error); ok {
-		if awsErr.Code() == fsx.ErrCodeIncompatibleParameterError {
 			return true
 		}
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix
**What is this PR about? / Why do we need it?**
This PR is meant to address this issue: https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/288
Right now an incompatible parameter error (like specifying throughput for SCRATCH_2), returns a ErrFsExistsDiffSize error. This error is both 1) wrong and 2) not descriptive for users to mitigate this issue. This PR just removes the if statement completely & associated function completely, so users get a descriptive error output. ex:
```
"GRPC error" err=<
	rpc error: code = Internal desc = Could not create volume "pvc-example_pvc": CreateFileSystem failed: IncompatibleParameterError: The storage throughput can not be specified for a lustre file system with DeploymentType=SCRATCH_2
	{
	  RespMetadata: {
	    StatusCode: 400,
	    RequestID: "example_request"
	  },
	  Message_: "The storage throughput can not be specified for a lustre file system with DeploymentType=SCRATCH_2"
	}
 >
```
**What testing is done?** 
- tested with storageclass that tries to specify throughput for scratch
- sanity testing