### PR TITLE
Update examples

### DIFF
--- a/examples/kubernetes/dynamic_provisioning/specs/pod.yaml
+++ b/examples/kubernetes/dynamic_provisioning/specs/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: amazonlinux:2
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
     volumeMounts:

--- a/examples/kubernetes/dynamic_provisioning_s3/specs/pod.yaml
+++ b/examples/kubernetes/dynamic_provisioning_s3/specs/pod.yaml
@@ -13,7 +13,7 @@ spec:
     lifecycle:
       postStart:
         exec:
-          command: ["amazon-linux-extras", "install", "lustre2.10", "-y"]
+          command: ["amazon-linux-extras", "install", "lustre", "-y"]
     volumeMounts:
     - name: persistent-storage
       mountPath: /data

--- a/examples/kubernetes/max_cache_tuning/specs/pod.yaml
+++ b/examples/kubernetes/max_cache_tuning/specs/pod.yaml
@@ -5,11 +5,11 @@ metadata:
 spec:
   initContainers:
   - name: set-lustre-cache
-    image: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.9.0
+    image: amazonlinux:2
+    command: ["/bin/sh","-c"]
+    args: ["amazon-linux-extras install lustre -y && /sbin/lctl set_param llite.*.max_cached_mb=32"]
     securityContext:
       privileged: true
-    command: ["/sbin/lctl"]
-    args: ["set_param", "llite.*.max_cached_mb=32"]
   containers:
   - name: app
     image: amazonlinux:2

--- a/examples/kubernetes/multiple_pods/specs/pod1.yaml
+++ b/examples/kubernetes/multiple_pods/specs/pod1.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: app1
-    image: centos
+    image: amazonlinux:2
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out1.txt; sleep 5; done"]
     volumeMounts:

--- a/examples/kubernetes/multiple_pods/specs/pod2.yaml
+++ b/examples/kubernetes/multiple_pods/specs/pod2.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: app2
-    image: busybox
+    image: amazonlinux:2
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out2.txt; sleep 5; done"]
     volumeMounts:

--- a/examples/kubernetes/static_provisioning/specs/pod.yaml
+++ b/examples/kubernetes/static_provisioning/specs/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: amazonlinux:2
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
     volumeMounts:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
Updating the examples. We recommend that users use the latest fsx-supported lustre client version (currently 2.12), so that was upgraded for the s3 example. Using the CSI driver image is unsupported for application/workload pods and highly discouraged, with the move to the min based image these workloads have a much higher likelihood of not working with the driver image. 

**What testing is done?** 
- deployed both pods to confirm they work as expected
- For the max cache tuning, collected output to validate:
```
output from initContainer, confirm the app works as intended:

Loaded plugins: ovl, priorities
Cleaning repos: amzn2-core amzn2extra-lustre
0 metadata files removed
...
 67  awscli1                  available    [ =stable ]
 68  php8.2                   available    [ =stable ]
 69  dnsmasq                  available    [ =stable ]
 70  unbound1.17              available    [ =stable ]
 71  golang1.19               available    [ =stable ]
llite.7b3jxbev-ffff88805b94f000.max_cached_mb=32
```