### PR TITLE
Allow for extra tags in controller deployment

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,6 +37,7 @@ func main() {
 	drv, err := driver.NewDriver(
 		driver.WithEndpoint(options.ServerOptions.Endpoint),
 		driver.WithMode(options.ServerOptions.DriverMode),
+		driver.WithExtraTags(options.ControllerOptions.ExtraTags),
 	)
 
 	if err != nil {

--- a/cmd/options/controller_options.go
+++ b/cmd/options/controller_options.go
@@ -22,7 +22,10 @@ import (
 
 // ControllerOptions contains options and configuration settings for the controller service.
 type ControllerOptions struct {
+	// ExtraTags is a map of tags that will be attached to each dynamically provisioned resource.
+	ExtraTags string
 }
 
 func (s *ControllerOptions) AddFlags(fs *flag.FlagSet) {
+	fs.StringVar(&s.ExtraTags, "extra-tags", "", "Extra tags to attach to each dynamically provisioned resource. It is a comma separated list of key value pairs like '<key1>=<value1>,<key2>=<value2>'")
 }

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,7 +1,8 @@
 # Driver Options
 There are a couple of driver options that can be passed as arguments when starting the driver container.
 
-| Option argument             | value sample                                      | default                                             | Description         |
-|-----------------------------|---------------------------------------------------|-----------------------------------------------------|---------------------|
-| endpoint                    | tcp://127.0.0.1:10000/                            | unix:///var/lib/csi/sockets/pluginproxy/csi.sock    | The socket on which the driver will listen for CSI RPCs|
-| logging-format              | json                                              | text                                                | Sets the log format. Permitted formats: text, json|
+| Option argument             | value sample                                      | default                                             | Description                                                                                 |
+|-----------------------------|---------------------------------------------------|-----------------------------------------------------|---------------------------------------------------------------------------------------------|
+| endpoint                    | tcp://127.0.0.1:10000/                            | unix:///var/lib/csi/sockets/pluginproxy/csi.sock    | The socket on which the driver will listen for CSI RPCs                                     |
+| extra-tags                  | key1=value1,key2=value2                           |                                                     | Tags specified in the controller spec are attached to each dynamically provisioned resource |
+| logging-format              | json                                              | text                                                | Sets the log format. Permitted formats: text, json                                          |

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -213,10 +213,18 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		fsOptions.CapacityGiB = util.RoundUpVolumeSize(capRange.GetRequiredBytes(), fsOptions.DeploymentType, fsOptions.StorageType, fsOptions.PerUnitStorageThroughput)
 	}
 
+	var tagArray []string
+	optionsTags := d.driverOptions.extraTags
+
+	if optionsTags != "" {
+		tagArray = strings.Split(optionsTags, ",")
+	}
+
 	if val, ok := volumeParams[volumeParamsExtraTags]; ok {
 		extraTags := strings.Split(val, ",")
-		fsOptions.ExtraTags = extraTags
+		tagArray = append(tagArray, extraTags...)
 	}
+	fsOptions.ExtraTags = tagArray
 
 	fs, err := d.cloud.CreateFileSystem(ctx, volName, fsOptions)
 	if err != nil {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -52,8 +52,9 @@ type Driver struct {
 }
 
 type DriverOptions struct {
-	endpoint string
-	mode     string
+	endpoint  string
+	mode      string
+	extraTags string
 }
 
 func NewDriver(options ...func(*DriverOptions)) (*Driver, error) {
@@ -141,5 +142,11 @@ func WithEndpoint(endpoint string) func(*DriverOptions) {
 func WithMode(mode string) func(*DriverOptions) {
 	return func(o *DriverOptions) {
 		o.mode = mode
+	}
+}
+
+func WithExtraTags(extraTags string) func(*DriverOptions) {
+	return func(o *DriverOptions) {
+		o.extraTags = extraTags
 	}
 }


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
new feature

**What is this PR about? / Why do we need it?**
allows users to set extra tags in the controller deployment yaml, which will in turn propagate for dynamic provisioning

**What testing is done?** 
- tested with new tags
- tested with duplicate tags between storageclass and controller-deployment (resulted in error as expected)


This change is based off of this commit: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/commit/7c17cb56a2e3856cc235078c00dc7c58a3122084 
