### PR TITLE
Remove hostNetwork from helm and manifests

### DIFF
--- a/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
@@ -31,7 +31,6 @@ spec:
         {{- with .Values.controller.nodeSelector }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      hostNetwork: true
       serviceAccountName: {{ .Values.controller.serviceAccount.name }}
       priorityClassName: system-cluster-critical
       tolerations:

--- a/charts/aws-fsx-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-fsx-csi-driver/templates/node-daemonset.yaml
@@ -30,7 +30,6 @@ spec:
         {{- with .Values.node.nodeSelector }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      hostNetwork: true
       dnsPolicy: {{ .Values.node.dnsPolicy }}
       {{- with .Values.node.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -20,7 +20,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      hostNetwork: true
       serviceAccountName: fsx-csi-controller-sa
       priorityClassName: system-cluster-critical
       tolerations:

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -19,7 +19,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      hostNetwork: true
       dnsPolicy: ClusterFirst
       serviceAccountName: fsx-csi-node-sa
       priorityClassName: system-node-critical


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
fix
**What is this PR about? / Why do we need it?**
With the changes in this [PR](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/309), specifically the k8s fallback, the driver no longer needs `hostNetwork: true`. 
Related PRs:
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/907
https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/681

**What testing is done?** 
I created a cluster with pod IMDS disabled and removed `hostNetwork: true` from the deployment files. I successfully tested dynamic provisioning + having a workload pod write to the dynamically provisioned file system