### PR TITLE
Release 0.10.1 - part 3/3, cherry-pick to master

### DIFF
--- a/CHANGELOG-0.x.md
+++ b/CHANGELOG-0.x.md
@@ -1,3 +1,21 @@
+# v0.10.1
+
+### Announcement
+To improve the security of the container images, the base image will be substantially reduced in scope to only contain the necessary driver dependencies in an upcoming release.
+**The CSI driver image should only be used in the CSI driver Deployment and Daemonset pods as documented in our Helm chart and Kustomize manifests. While this change won’t negatively impact workloads that rely on volumes managed by the FSx for Lustre CSI Driver, it may break unsupported uses of the CSI driver image outside of the aforementioned official deployment methods.**
+
+### Notable Changes
+* Add inflight check to node operations ([#325](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/325), [@jacobwolfaws](https://github.com/jacobwolfaws))
+* Allow for extra tags in controller deployment ([#331](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/331), [@jacobwolfaws](https://github.com/jacobwolfaws))
+* Remove hostNetwork from helm and manifests ([#332](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/332), [@jacobwolfaws](https://github.com/jacobwolfaws))
+
+### Bug fixes
+* Remove ErrFsExistsDiffSize error on incompatible parameter ([#322](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/322), [@jacobwolfaws](https://github.com/jacobwolfaws))
+
+### Improvements
+* Update log functions ([#320](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/320), [@jacobwolfaws](https://github.com/jacobwolfaws))
+* Bump sidecar images ([#333](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/333), [@jacobwolfaws](https://github.com/jacobwolfaws))
+
 # v0.10.0
 
 ### Misc.

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION?=v0.10.0
+VERSION?=v0.10.1
 
 PKG=sigs.k8s.io/aws-fsx-csi-driver
 GIT_COMMIT?=$(shell git rev-parse HEAD)

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/cloud.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE} -s -w"
 
 GO111MODULE=on
-GOPROXY=direct
+GOPROXY=https://proxy.golang.org,direct
 GOPATH=$(shell go env GOPATH)
 GOOS=$(shell go env GOOS)
 GOBIN=$(shell pwd)/bin

--- a/charts/aws-fsx-csi-driver/CHANGELOG.md
+++ b/charts/aws-fsx-csi-driver/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Helm chart
 
+# v1.6.1
+* Removed hostNetwork: true from helm deployment
+* Allow for extra tags in controller deployment
+* Add region for controller to helm chart
+
 # v1.6.0
 * Use driver image 0.10.0
 * Add driver modes for controller and node pods

--- a/charts/aws-fsx-csi-driver/Chart.yaml
+++ b/charts/aws-fsx-csi-driver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "0.10.0"
+appVersion: "0.10.1"
 name: aws-fsx-csi-driver
 description: A Helm chart for AWS FSx for Lustre CSI Driver
-version: 1.6.0
+version: 1.6.1
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-fsx-csi-driver
 sources:

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver
-  tag: v0.10.0
+  tag: v0.10.1
   pullPolicy: IfNotPresent
 
 csidriver:

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -30,7 +30,7 @@ spec:
           tolerationSeconds: 300
       containers:
         - name: fsx-plugin
-          image: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.10.0
+          image: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.10.1
           imagePullPolicy: IfNotPresent
           args:
             - --mode=controller

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         - name: fsx-plugin
           securityContext:
             privileged: true
-          image: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.10.0
+          image: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.10.1
           imagePullPolicy: IfNotPresent
           args:
             - --mode=node

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -5,4 +5,4 @@ bases:
 images:
   - name: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-fsx-csi-driver
-    newTag: v0.10.0
+    newTag: v0.10.1

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ For installation and deployment instructions, please refer to our [installation 
 ### CSI Specification Compatibility Matrix
 | AWS FSx for Lustre CSI Driver \ CSI Version | v0.3.0 | v1.x.x |
 |---------------------------------------------|--------|--------|
+| v0.10.1                                     | no     | yes    |
 | v0.10.0                                     | no     | yes    |
 | v0.9.0                                      | no     | yes    |
 | v0.8.3                                      | no     | yes    |
@@ -41,6 +42,7 @@ The following sections are Kubernetes-specific. If you are a Kubernetes user, us
 ### Kubernetes Version Compatibility Matrix
 | AWS FSx for Lustre CSI Driver \ Kubernetes Version | v1.11 | v1.12 | v1.13 | v1.14-16 | v1.17+ |
 |----------------------------------------------------|-------|-------|-------|----------|--------|
+| v0.10.1                                            | no    | no    | no    | no       | yes    |
 | v0.10.0                                            | no    | no    | no    | no       | yes    |
 | v0.9.0                                             | no    | no    | no    | no       | yes    |
 | v0.8.3                                             | no    | no    | no    | no       | yes    |
@@ -59,6 +61,7 @@ The following sections are Kubernetes-specific. If you are a Kubernetes user, us
 ### Container Images
 | FSx CSI Driver Version | Image                                                    |
 |------------------------|----------------------------------------------------------|
+| v0.10.1                | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.10.1 |
 | v0.10.0                | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.10.0 |
 | v0.9.0                 | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.9.0  |
 | v0.8.3                 | public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver:v0.8.3  |


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
further minimize the dependencies that the lustre csi driver image pulls in by only pulling in the needed mounting binary

**What testing is done?** 
- manual testing of dynamic provisioning + mounting a file system
