### PR TITLE
Only trigger container images wf on v* tag

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -1,6 +1,10 @@
 name: Container Images
 
-on: push
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 env:
   REGION : "us-east-1"
 jobs:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix
**What is this PR about? / Why do we need it?**
only trigger the container images workflow on tags that are "v*". This will stop needless workflows from getting triggered that sometimes require manual intervention from OWNERs: https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/344
**What testing is done?** 
