### PR TITLE
Change csidriver fsGroupPolicy to File

### DIFF
--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -8,7 +8,7 @@ image:
   pullPolicy: IfNotPresent
 
 csidriver:
-  fsGroupPolicy: ReadWriteOnceWithFSType
+  fsGroupPolicy: File
 
 sidecars:
   livenessProbe:

--- a/deploy/kubernetes/base/csidriver.yaml
+++ b/deploy/kubernetes/base/csidriver.yaml
@@ -6,4 +6,4 @@ metadata:
   name: fsx.csi.aws.com
 spec:
   attachRequired: false
-  fsGroupPolicy: ReadWriteOnceWithFSType
+  fsGroupPolicy: File


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
Changing the fsGroupPolicy from ReadWriteOnceWithFSType to File. https://kubernetes-csi.github.io/docs/support-fsgroup.html#supported-modes

> File: Indicates that the CSI volume driver supports volume ownership and permission change via fsGroup, and Kubernetes may use fsGroup to change permissions and ownership of the volume to match user requested fsGroup in the pod's SecurityPolicy regardless of fstype or access mode.

This is being done to allow users to more easily customize ownership and permission of the volume. Note that ebs csi driver has this set already: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/templates/csidriver.yaml

**What testing is done?** 

- dynamically provisioned a volume and and had an application pod with this securityContext:
```
securityContext:
    runAsUser: 1000
    runAsGroup: 3000
    fsGroup: 2000
    fsGroupChangePolicy: "OnRootMismatch"
```
mount and write to the filesystem