### PR TITLE
Add taint removal retry mechanism

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,6 +38,7 @@ func main() {
 		driver.WithEndpoint(options.ServerOptions.Endpoint),
 		driver.WithMode(options.ServerOptions.DriverMode),
 		driver.WithExtraTags(options.ControllerOptions.ExtraTags),
+		driver.WithRetryTaintRemoval(options.NodeOptions.RetryTaintRemoval),
 	)
 
 	if err != nil {

--- a/cmd/options/node_options.go
+++ b/cmd/options/node_options.go
@@ -22,7 +22,9 @@ import (
 
 // NodeOptions contains options and configuration settings for the node service.
 type NodeOptions struct {
+	RetryTaintRemoval bool
 }
 
-func (o *NodeOptions) AddFlags(fs *flag.FlagSet) {
+func (s *NodeOptions) AddFlags(fs *flag.FlagSet) {
+	fs.BoolVar(&s.RetryTaintRemoval, "retry-taint-removal", false, "Max number of tries for node taint removal")
 }

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,8 +1,9 @@
 # Driver Options
 There are a couple of driver options that can be passed as arguments when starting the driver container.
 
-| Option argument             | value sample                                      | default                                             | Description                                                                                 |
-|-----------------------------|---------------------------------------------------|-----------------------------------------------------|---------------------------------------------------------------------------------------------|
-| endpoint                    | tcp://127.0.0.1:10000/                            | unix:///var/lib/csi/sockets/pluginproxy/csi.sock    | The socket on which the driver will listen for CSI RPCs                                     |
-| extra-tags                  | key1=value1,key2=value2                           |                                                     | Tags specified in the controller spec are attached to each dynamically provisioned resource |
-| logging-format              | json                                              | text                                                | Sets the log format. Permitted formats: text, json                                          |
+| Option argument     | value sample            | default                                          | Description                                                                                      |
+|---------------------|-------------------------|--------------------------------------------------|--------------------------------------------------------------------------------------------------|
+| endpoint            | tcp://127.0.0.1:10000/  | unix:///var/lib/csi/sockets/pluginproxy/csi.sock | The socket on which the driver will listen for CSI RPCs                                          |
+| extra-tags          | key1=value1,key2=value2 |                                                  | Tags specified in the controller spec are attached to each dynamically provisioned resource      |
+| logging-format      | json                    | text                                             | Sets the log format. Permitted formats: text, json                                               |
+| retry-taint-removal | true                    | false                                            | If set to true, will keep retrying node taint removal for 90 seconds with an exponential backoff |

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -52,9 +52,10 @@ type Driver struct {
 }
 
 type DriverOptions struct {
-	endpoint  string
-	mode      string
-	extraTags string
+	endpoint          string
+	mode              string
+	extraTags         string
+	retryTaintRemoval bool
 }
 
 func NewDriver(options ...func(*DriverOptions)) (*Driver, error) {
@@ -148,5 +149,11 @@ func WithMode(mode string) func(*DriverOptions) {
 func WithExtraTags(extraTags string) func(*DriverOptions) {
 	return func(o *DriverOptions) {
 		o.extraTags = extraTags
+	}
+}
+
+func WithRetryTaintRemoval(retryRemoval bool) func(options *DriverOptions) {
+	return func(o *DriverOptions) {
+		o.retryTaintRemoval = retryRemoval
 	}
 }


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
both
**What is this PR about? / Why do we need it?**
PR is to give users a retry mechanism (if they so choose) for the csi driver. This allows users to address a noisy/overloaded control plane that can result in this error `connect: network is unreachable` when trying to remove the start up taint

**What testing is done?** 
Tested locally with
1) no retry mechanism
2) retry mechanism, passed on first attempt

to sanity check and make sure this doesn't impact nodes that don't have an error on first pass.

**Things to discuss**
1) flag name, is it clear and do we want something less wordy?
2) Advice on refactoring code/breaking out retry function so we can unit test

@torredil @ConnorJC3 since EBS may want to introduce a similar feature / port over this code once PR is merged