### PR TITLE
Show latest release badge in README

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -25,3 +25,4 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           config: .github/cr.yaml
+          mark_as_latest: false

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,4 @@
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/kubernetes-sigs/aws-fsx-csi-driver)](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes-sigs/aws-fsx-csi-driver)](https://goreportcard.com/report/github.com/kubernetes-sigs/aws-fsx-csi-driver)
 
 ## Amazon FSx for Lustre CSI Driver


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
This PR is about showing the latest release in the README. To show the correct release, added `mark_as_latest: false` to the helm chart release
**What testing is done?** 
You can see in my repo: https://github.com/jacobwolfaws/aws-fsx-csi-driver that the badge shows the latest marked release in the csi driver (which is currently a helm release, since we mark all releases as the latest currently). The aws-ebs-csi-driver also implements this same approach: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/.github/workflows/helm-chart-release.yaml#L28
