### PR TITLE
chore: Bump aws-sdk-go for EKS Pod Identity support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module sigs.k8s.io/aws-fsx-csi-driver
 
 require (
-	github.com/aws/aws-sdk-go v1.47.4
+	github.com/aws/aws-sdk-go v1.50.3
 	github.com/container-storage-interface/spec v1.9.0
 	github.com/golang/mock v1.6.0
 	github.com/kubernetes-csi/csi-test v2.0.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go v1.47.4 h1:IyhNbmPt+5ldi5HNzv7ZnXiqSglDMaJiZlzj4Yq3qnk=
-github.com/aws/aws-sdk-go v1.47.4/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
+github.com/aws/aws-sdk-go v1.50.3 h1:NnXC/ukOakZbBwQcwAzkAXYEB4SbWboP9TFx9vvhIrE=
+github.com/aws/aws-sdk-go v1.50.3/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bumps up aws-sdk-go to v1.50.3.

**What is this PR about? / Why do we need it?**
AWS SDK [v.1.47.11](https://github.com/aws/aws-sdk-go/releases/tag/v1.47.11) updated credential provider logic support which is required by pods which need to use the newly launched [Amazon EKS Pod Identities](https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-eks-pod-identity/).

Also see https://docs.aws.amazon.com/eks/latest/userguide/pod-id-minimum-sdk.html for further information.

**What testing is done?** 

Ran `make` and `make test` with no errors.

