### PR TITLE
pin to latest AL2 5.10 kernel AMI for e2e

### DIFF
--- a/hack/kops-patch-node.yaml
+++ b/hack/kops-patch-node.yaml
@@ -1,4 +1,4 @@
 spec:
-  image: 137112412989/amzn2-ami-hvm-2.0.20220218.3-x86_64-gp2
+  image: 137112412989/amzn2-ami-kernel-5.10-hvm-2.0.20240412.0-x86_64-gp2
   instanceMetadata:
     httpPutResponseHopLimit: 3


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
- the pinned AMI is deprecated, pinning to the latest available AMI to avoid this event from occurring again for a while
- tracking work to unpin ami here: https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/326
- unblocking this PR: https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/377

**What testing is done?** 
