### PR TITLE
Make Volume resizing/creation timeout scale with volume size

### DIFF
--- a/pkg/cloud/fakes.go
+++ b/pkg/cloud/fakes.go
@@ -98,7 +98,7 @@ func (c *FakeCloudProvider) DescribeFileSystem(ctx context.Context, volumeID str
 	return nil, ErrNotFound
 }
 
-func (c *FakeCloudProvider) WaitForFileSystemAvailable(ctx context.Context, fileSystemId string) error {
+func (c *FakeCloudProvider) WaitForFileSystemAvailable(ctx context.Context, fileSystemId string, sizeGiB int64) error {
 	return nil
 }
 

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -236,7 +236,7 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		}
 	}
 
-	err = d.cloud.WaitForFileSystemAvailable(ctx, fs.FileSystemId)
+	err = d.cloud.WaitForFileSystemAvailable(ctx, fs.FileSystemId, fsOptions.CapacityGiB)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Filesystem is not ready: %v", err)
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

Hopefully solves Issue: https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/382

Increases volume creation/resizing timeout by introducing an additional linear factor for waiting longer on larger volumes.

This was done based on datapoints that @jon-rei gathered in [this](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/382#issuecomment-2206176552) comment. I made a crude linear regression onto these datapoints:

![image](https://github.com/kubernetes-sigs/aws-fsx-csi-driver/assets/30271979/e275db3e-286f-4d32-b024-195973394e12)

The resulting formula for timeout would be (`T` timeout [s], `v` volume size in GiB): `T(v) = 454 + 2.18 * 10^(-3)*v`
So round about 7.5 min statically and for every GiB, we'd have to wait ~2ms additionally. I used 10 min statically and 5ms for every GiB to be on the safer side.

**What testing is done?** 

None unfortunately, I don't have an easy way of testing this.





