### PR TITLE
Make Volume creation timeout configurable

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -117,7 +117,7 @@ type Cloud interface {
 	ResizeFileSystem(ctx context.Context, fileSystemId string, newSizeGiB int64) (int64, error)
 	DeleteFileSystem(ctx context.Context, fileSystemId string) (err error)
 	DescribeFileSystem(ctx context.Context, fileSystemId string) (fs *FileSystem, err error)
-	WaitForFileSystemAvailable(ctx context.Context, fileSystemId string) error
+	WaitForFileSystemAvailable(ctx context.Context, fileSystemId string, timeout time.Duration) error
 	WaitForFileSystemResize(ctx context.Context, fileSystemId string, resizeGiB int64) error
 }
 
@@ -329,8 +329,8 @@ func (c *cloud) DescribeFileSystem(ctx context.Context, fileSystemId string) (*F
 	}, nil
 }
 
-func (c *cloud) WaitForFileSystemAvailable(ctx context.Context, fileSystemId string) error {
-	err := wait.Poll(PollCheckInterval, PollCheckTimeout, func() (done bool, err error) {
+func (c *cloud) WaitForFileSystemAvailable(ctx context.Context, fileSystemId string, timeout time.Duration) error {
+	err := wait.Poll(PollCheckInterval, timeout, func() (done bool, err error) {
 		fs, err := c.getFileSystem(ctx, fileSystemId)
 		if err != nil {
 			return true, err

--- a/pkg/cloud/fakes.go
+++ b/pkg/cloud/fakes.go
@@ -98,7 +98,7 @@ func (c *FakeCloudProvider) DescribeFileSystem(ctx context.Context, volumeID str
 	return nil, ErrNotFound
 }
 
-func (c *FakeCloudProvider) WaitForFileSystemAvailable(ctx context.Context, fileSystemId string) error {
+func (c *FakeCloudProvider) WaitForFileSystemAvailable(ctx context.Context, fileSystemId string, timeout time.Duration) error {
 	return nil
 }
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

Hopefully solves Issue: https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/382

Made volume creation timeout configurable by introducing a new Volume parameter "pollTimeout". This is a timeout in seconds that will be used on creation of the volume.

Found no way easily right now to make a poll timeout during resizing of the volume configurable.

**What testing is done?** 

None unfortunately, I don't have an easy way of testing this.





