### PR TITLE
ci: Add permissions to release job and update Chart Releaser

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write # Needed for creating and editing releases
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,7 +22,7 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,8 @@ on:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 jobs:
   build:
+    permissions:
+      contents: write # Needed for creating and editing releases
     name: Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Current release has the following error, adding write permissions so it can create the new release. Also bumping chart releaser to version 1.6 where the `mark_as_latest` option was added.

`Error: error creating GitHub release helm-chart-aws-fsx-csi-driver-1.9.1: POST https://api.github.com/repos/kubernetes-sigs/aws-fsx-csi-driver/releases: 403 Resource not accessible by integration []`

`Warning: Unexpected input(s) 'mark_as_latest', valid inputs are ['version', 'config', 'charts_dir', 'charts_repo_url']`

**What is this PR about? / Why do we need it?**
The project is not able to create new helm chart releases using chart-releaser

