### PR TITLE
Sanitize CSI request logs

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -110,7 +110,7 @@ func newControllerService(driverOptions *DriverOptions) controllerService {
 	}
 }
 func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
-	klog.V(4).InfoS("CreateVolume: called", "args", req)
+	klog.V(4).InfoS("CreateVolume: called", "args", util.SanitizeRequest(req))
 	volName := req.GetName()
 	if len(volName) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume name not provided")
@@ -274,7 +274,7 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 }
 
 func (d *controllerService) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
-	klog.V(4).InfoS("DeleteVolume: called", "args", req)
+	klog.V(4).InfoS("DeleteVolume: called", "args", util.SanitizeRequest(req))
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
@@ -310,7 +310,7 @@ func (d *controllerService) ControllerModifyVolume(ctx context.Context, req *csi
 }
 
 func (d *controllerService) ControllerGetCapabilities(ctx context.Context, req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
-	klog.V(4).InfoS("ControllerGetCapabilities: called", "args", req)
+	klog.V(4).InfoS("ControllerGetCapabilities: called", "args", util.SanitizeRequest(req))
 	var caps []*csi.ControllerServiceCapability
 	for _, cap := range controllerCaps {
 		c := &csi.ControllerServiceCapability{
@@ -326,17 +326,17 @@ func (d *controllerService) ControllerGetCapabilities(ctx context.Context, req *
 }
 
 func (d *controllerService) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
-	klog.V(4).InfoS("GetCapacity: called", "args", req)
+	klog.V(4).InfoS("GetCapacity: called", "args", util.SanitizeRequest(req))
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 func (d *controllerService) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
-	klog.V(4).InfoS("ListVolumes: called", "args", req)
+	klog.V(4).InfoS("ListVolumes: called", "args", util.SanitizeRequest(req))
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
 func (d *controllerService) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
-	klog.V(4).InfoS("ValidateVolumeCapabilities: called", "args", req)
+	klog.V(4).InfoS("ValidateVolumeCapabilities: called", "args", util.SanitizeRequest(req))
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
@@ -403,7 +403,7 @@ func (d *controllerService) ListSnapshots(ctx context.Context, req *csi.ListSnap
 }
 
 func (d *controllerService) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
-	klog.V(4).InfoS("ControllerExpandVolume: called", "args", req)
+	klog.V(4).InfoS("ControllerExpandVolume: called", "args", util.SanitizeRequest(req))
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/aws-fsx-csi-driver/pkg/cloud"
 	"sigs.k8s.io/aws-fsx-csi-driver/pkg/driver/internal"
+	"sigs.k8s.io/aws-fsx-csi-driver/pkg/util"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
@@ -93,7 +94,7 @@ func (d *nodeService) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 }
 
 func (d *nodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
-	klog.V(4).InfoS("NodePublishVolume: called with", "args", req)
+	klog.V(4).InfoS("NodePublishVolume: called with", "args", util.SanitizeRequest(req))
 
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
@@ -181,7 +182,7 @@ func (d *nodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 }
 
 func (d *nodeService) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
-	klog.V(4).InfoS("NodeUnpublishVolume: called", "args", req)
+	klog.V(4).InfoS("NodeUnpublishVolume: called", "args", util.SanitizeRequest(req))
 
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
@@ -226,7 +227,7 @@ func (d *nodeService) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 }
 
 func (d *nodeService) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
-	klog.V(4).InfoS("NodeGetCapabilities: called", "args", req)
+	klog.V(4).InfoS("NodeGetCapabilities: called", "args", util.SanitizeRequest(req))
 	var caps []*csi.NodeServiceCapability
 	for _, cap := range nodeCaps {
 		c := &csi.NodeServiceCapability{
@@ -242,7 +243,7 @@ func (d *nodeService) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetC
 }
 
 func (d *nodeService) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
-	klog.V(4).InfoS("NodeGetInfo: called", "args", req)
+	klog.V(4).InfoS("NodeGetInfo: called", "args", util.SanitizeRequest(req))
 
 	return &csi.NodeGetInfoResponse{
 		NodeId: d.metadata.GetInstanceID(),

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/fsx/types"
@@ -117,4 +118,21 @@ func GetURLHost(urlStr string) (string, error) {
 	}
 
 	return u.Host, nil
+}
+
+// SanitizeRequest takes a request object and returns a copy of the request with
+// the "Secrets" field cleared.
+func SanitizeRequest(req interface{}) interface{} {
+	v := reflect.ValueOf(&req).Elem()
+	e := reflect.New(v.Elem().Type()).Elem()
+
+	e.Set(v.Elem())
+
+	f := reflect.Indirect(e).FieldByName("Secrets")
+
+	if f.IsValid() && f.CanSet() && f.Kind() == reflect.Map {
+		f.Set(reflect.MakeMap(f.Type()))
+		v.Set(e)
+	}
+	return req
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -19,6 +19,7 @@ package util
 import (
 	"fmt"
 	"math"
+	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/fsx/types"
@@ -316,6 +317,43 @@ func TestConvertToInt32(t *testing.T) {
 				if tc.expectedErr.Error() != err.Error() {
 					t.Fatalf("GetURLHost got wrong result. actual: %d, expected: %d", err, tc.expectedErr)
 				}
+			}
+		})
+	}
+}
+
+type TestRequest struct {
+	Name    string
+	Secrets map[string]string
+}
+
+func TestSanitizeRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      interface{}
+		expected interface{}
+	}{
+		{
+			name: "Request with Secrets",
+			req: &TestRequest{
+				Name: "Test",
+				Secrets: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			expected: &TestRequest{
+				Name:    "Test",
+				Secrets: map[string]string{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeRequest(tt.req)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("SanitizeRequest() = %v, expected %v", result, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
security enhancement
**What is this PR about? / Why do we need it?**
Adds change from https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2037

While FSx CSI Driver does not currently support [Token Requests](https://kubernetes-csi.github.io/docs/token-requests.html), adding this additional security measure to align on best practice and to avoid future upstream regressions from logging secrets.

**What testing is done?** 
make, make-test
Manually checked secrets are not logged