### PR TITLE
Handle empty and misconfigured extraTags in controller

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -249,8 +249,12 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		tagArray = strings.Split(optionsTags, ",")
 	}
 
-	if val, ok := volumeParams[volumeParamsExtraTags]; ok {
+	if val, ok := volumeParams[volumeParamsExtraTags]; ok && len(val) > 0 {
 		extraTags := strings.Split(val, ",")
+		err := validateExtraTags(extraTags)
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 		tagArray = append(tagArray, extraTags...)
 	}
 	fsOptions.ExtraTags = tagArray
@@ -473,4 +477,14 @@ func newCreateVolumeResponse(fs *cloud.FileSystem) *csi.CreateVolumeResponse {
 			},
 		},
 	}
+}
+
+func validateExtraTags(tags []string) error {
+	for _, tag := range tags {
+		tagSplit := strings.Split(tag, "=")
+		if len(tagSplit) != 2 {
+			return fmt.Errorf("invalid extraTag %s was provided", tag)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix.
**What is this PR about? / Why do we need it?**
CSI Driver panics when empty string given for extraTags as seen in https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/401, same behavior would happen with misconfigured tags where len <2.
**What testing is done?** 
- Added sanity tests for two new cases being tracked (misconfigured tags, empty tags)
- tested in my dev EKS setup