### PR TITLE
CI ONLY DO NOT MERGE

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -74,6 +74,12 @@ TEST_EXTRA_FLAGS=${TEST_EXTRA_FLAGS:-}
 
 CLEAN=${CLEAN:-"true"}
 
+FILE_SYSTEM_IDS=$(aws --region ${REGION} fsx describe-file-systems --query "FileSystems[?FileSystemType=='LUSTRE'].FileSystemId" --output text)
+for FILE_SYSTEM_ID in $FILE_SYSTEM_IDS
+do
+    aws --region ${REGION} fsx delete-file-system --file-system-id ${FILE_SYSTEM_ID}
+done
+
 loudecho "Testing in region ${REGION} and zones ${ZONES}"
 mkdir -p "${BIN_DIR}"
 export PATH=${PATH}:${BIN_DIR}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
deletes stranded filesystems that are blocking tests like here: https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/413

Need to add the aws-janitor

**What testing is done?** 
