### PR TITLE
Update provenance check for changed message

### DIFF
--- a/hack/provenance
+++ b/hack/provenance
@@ -26,9 +26,9 @@
 # Thus, this script echos back the flag `--provenance=false` if and only
 # if the local buildx installation supports it. If not, it exits silently.
 
-BUILDX_TEST=`docker buildx build --provenance=false 2>&1`
-if [[ "${BUILDX_TEST}" == *"See 'docker buildx build --help'."* ]]; then
-  if [[ "${BUILDX_TEST}" == *"requires exactly 1 argument"* ]] && ! docker buildx inspect | grep -qE "^Driver:\s*docker$"; then
+BUILDX_TEST=$(docker buildx build --provenance=false 2>&1)
+if [[ "${BUILDX_TEST}" == *"'docker buildx build --help'"* ]]; then
+  if [[ "${BUILDX_TEST}" == *"1 argument"* ]] && ! docker buildx inspect | grep -qE "^Driver:\s*docker$"; then
     echo "--provenance=false"
   fi
 else


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix
**What is this PR about? / Why do we need it?**
In the provenance check we were checking using this pattern `*"See 'docker buildx build --help'."*` but the message was updated to be `Run 'docker buildx build --help' for more information`. Just reducing the specificity of the check should be sufficient

**What testing is done?** 
Ran builld from personal, not seeing an error message from provenance check anymore