### PR TITLE
Allow the timeout of the csi driver to be set

### DIFF
--- a/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
@@ -93,7 +93,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.sidecars.provisioner.logLevel }}
-            - --timeout=5m
+            - --timeout={{ .Values.controller.timeout| default "5m" }}
             - --extra-create-metadata
             - --leader-election=true
           env:

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -65,6 +65,8 @@ controller:
     - effect: NoExecute
       operator: Exists
       tolerationSeconds: 300
+  # Specify the timeout of all calls to the CSI driver.
+  # timeout: 5m
 
 node:
   mode: node


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This allows the configuration of a previously hard coded setting that controls the timeout of call to the csi driver.
https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/433

**What is this PR about? / Why do we need it?**
AWS had an issue taking the provisioning of file systems longer than the 5m default. Now this setting is configurable.

**What testing is done?** 
Deployment with a timeout of 15m during the time that provisioning was taking longer than 5min.
