### PR TITLE
Add default resources values/ security context/ add more flexibility …

### DIFF
--- a/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         {{- end }}
       containers:
         - name: fsx-plugin
-          image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
+          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --mode={{ .Values.controller.mode }}
@@ -65,10 +65,10 @@ spec:
                   name: aws-secret
                   key: access_key
                   optional: true
-            {{- with .Values.controller.region }}
+              {{- with .Values.controller.region }}
             - name: AWS_REGION
               value: {{ . }}
-            {{- end }}
+              {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -89,7 +89,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         - name: csi-provisioner
-          image: {{ printf "%s:%s" .Values.sidecars.provisioner.image.repository .Values.sidecars.provisioner.image.tag }}
+          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.provisioner.image.repository .Values.sidecars.provisioner.image.tag }}
           args:
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.sidecars.provisioner.logLevel }}
@@ -107,7 +107,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         - name: csi-resizer
-          image: {{ printf "%s:%s" .Values.sidecars.resizer.image.repository .Values.sidecars.resizer.image.tag }}
+          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.resizer.image.repository .Values.sidecars.resizer.image.tag }}
           args:
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.sidecars.resizer.logLevel }}
@@ -124,7 +124,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         - name: liveness-probe
-          image: {{ printf "%s:%s" .Values.sidecars.livenessProbe.image.repository .Values.sidecars.livenessProbe.image.tag }}
+          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.livenessProbe.image.repository .Values.sidecars.livenessProbe.image.tag }}
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9910
@@ -138,3 +138,11 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
+      {{- with .Values.controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/aws-fsx-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-fsx-csi-driver/templates/node-daemonset.yaml
@@ -40,13 +40,13 @@ spec:
       tolerations:
         {{- if .Values.node.tolerateAllTaints }}
         - operator: Exists
-        {{- else }}
-        {{- with .Values.node.tolerations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+          {{- else }}
+          {{- with .Values.node.tolerations }}
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
         - key: "fsx.csi.aws.com/agent-not-ready"
           operator: "Exists"
-        {{- end }}
+          {{- end }}
       {{- with .Values.node.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -68,10 +68,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            {{- with .Values.node.region }}
+              {{- with .Values.node.region }}
             - name: AWS_REGION
               value: {{ . }}
-            {{- end }}
+              {{- end }}
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet

--- a/charts/aws-fsx-csi-driver/templates/pdb.yaml
+++ b/charts/aws-fsx-csi-driver/templates/pdb.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.controller.podDisruptionBudget.enabled (not .Values.nodeComponentOnly) -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: fsx-csi-controller
+  namespace: kube-system
+  labels:
+    {{- include "aws-fsx-csi-driver.labels" . | nindent 4 }} 
+spec:
+  selector:
+    matchLabels:
+      app: fsx-csi-controller
+      {{- include "aws-fsx-csi-driver.selectorLabels" . | nindent 6 }} 
+  {{- if .Values.controller.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ .Values.controller.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  {{- end }}
+  {{- if le (.Values.controller.replicaCount | int) 2 }}
+  maxUnavailable: 1
+  {{- else }}
+  minAvailable: 2
+  {{- end }}
+{{- end -}}

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/fsx-csi-driver/aws-fsx-csi-driver
-  tag: v1.4.0
+  tag: "v1.4.0"
   pullPolicy: IfNotPresent
 
 csidriver:
@@ -14,37 +14,75 @@ sidecars:
   livenessProbe:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-      tag: v2.15.0-eks-1-33-3
+      tag: v2.15.0-eks-1-33-9
       pullPolicy: IfNotPresent
-    resources: {}
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 128Mi
+    securityContext:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
   nodeDriverRegistrar:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-      tag: v2.13.0-eks-1-33-3
+      tag: v2.13.0-eks-1-33-9
       pullPolicy: IfNotPresent
     logLevel: 2
-    resources: {}
+    resources: 
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 128Mi
+    securityContext:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
   provisioner:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-      tag: v5.2.0-eks-1-33-3
+      tag: v5.2.0-eks-1-33-9
       pullPolicy: IfNotPresent
     logLevel: 2
-    resources: {}
+    resources: 
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 128Mi
+    securityContext:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
   resizer:
     image:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
-      tag: v1.13.2-eks-1-33-3
+      tag: v1.13.2-eks-1-33-9
       pullPolicy: IfNotPresent
     logLevel: 2
-    resources: {}
+    resources: 
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 128Mi
+    securityContext:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
 
 controller:
   mode: controller
   loggingFormat: text
   nodeSelector: {}
   replicaCount: 2
-  resources: {}
+  #If you do want to specify resources, uncomment the following lines, adjust them as necessary
+  resources:
+    requests:
+      cpu: 10m
+      memory: 40Mi
+    limits:
+      memory: 256Mi
   serviceAccount:
     # Specifies whether a service account should be created
     create: true
@@ -65,13 +103,54 @@ controller:
     - effect: NoExecute
       operator: Exists
       tolerationSeconds: 300
+  # securityContext on the controller pod
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 0
+    runAsGroup: 0
+    fsGroup: 0
+  # securityContext on the controller container
+  # Setting privileged=false will cause the "delete-access-point-root-dir" controller option to fail
+  containerSecurityContext:
+    privileged: true
+  leaderElectionRenewDeadline: 10s
+  leaderElectionLeaseDuration: 15s
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                  - fargate
+                  - hybrid
+  # topologySpreadConstraints:
+  #  - maxSkew: 1
+  #    topologyKey: topology.kubernetes.io/zone
+  #    whenUnsatisfiable: ScheduleAnyway
+  #  - maxSkew: 1
+  #    topologyKey: kubernetes.io/hostname
+  #    whenUnsatisfiable: ScheduleAnyway
+  topologySpreadConstraints: []  
+  podDisruptionBudget:
+    # Warning: Disabling PodDisruptionBudget may lead to delays in stateful workloads starting due to controller
+    # pod restarts or evictions.
+    enabled: true
 
 node:
   mode: node
   loggingFormat: text
   logLevel: 2
   nodeSelector: {}
-  resources: {}
+  #If you do want to specify resources, uncomment the following lines, adjust them as necessary,
+  resources:
+    requests:
+      cpu: 10m
+      memory: 40Mi
+    limits:
+      memory: 256Mi   
   dnsPolicy: ClusterFirst
   dnsConfig:
     {}
@@ -87,13 +166,18 @@ node:
     #  eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/fsx-csi-role
     name: fsx-csi-node-sa
     annotations: {}
+  healthPort: 9809
+  # securityContext on the node pod
+  securityContext:
+    # The node pod must be run as root to bind to the registration/driver sockets
+    runAsNonRoot: false
+    runAsUser: 0
+    runAsGroup: 0
+    fsGroup: 0
+  env: []
+  volumes: []
+  volumeMounts: []
   podAnnotations: {}
-  # AWS region to use. If not specified then the region will be looked up via the AWS EC2 metadata
-  # service.
-  # ---
-  # region: us-east-1
-  region:
-  terminationGracePeriodSeconds: 30
   tolerateAllTaints: true
   tolerations:
     - operator: Exists
@@ -108,8 +192,15 @@ node:
             operator: NotIn
             values:
             - fargate
-
+            - hybrid 
+            
 nameOverride: ""
 fullnameOverride: ""
 
 imagePullSecrets: []
+
+nodeComponentOnly: false
+# nodeComponentOnly: true
+  # Only deploys the node DaemonSet, Skips controller deployment
+# nodeComponentOnly: false (default)
+  # Deploys both controller and node components, normal full deployment

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -71,8 +71,14 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 2
             failureThreshold: 5
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 40Mi
         - name: csi-provisioner
-          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v5.2.0-eks-1-33-3
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v5.2.0-eks-1-33-9
           args:
             - --csi-address=$(ADDRESS)
             - --v=2
@@ -85,8 +91,14 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
         - name: csi-resizer
-          image: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.13.2-eks-1-33-3
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.13.2-eks-1-33-9
           args:
             - --csi-address=$(ADDRESS)
             - --v=2
@@ -98,14 +110,37 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.15.0-eks-1-33-3
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.15.0-eks-1-33-9
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9910
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
       volumes:
         - name: socket-dir
           emptyDir: {}
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
+                - hybrid
+            weight: 1

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -21,7 +21,7 @@ spec:
         kubernetes.io/os: linux
       dnsPolicy: ClusterFirst
       serviceAccountName: fsx-csi-node-sa
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 
       priorityClassName: system-node-critical
       tolerations:
         - operator: Exists
@@ -34,6 +34,7 @@ spec:
                 operator: NotIn
                 values:
                 - fargate
+                - hybrid
       containers:
         - name: fsx-plugin
           securityContext:
@@ -74,8 +75,14 @@ spec:
             preStop:
               exec:
                 command: [ "/bin/aws-fsx-csi-driver", "pre-stop-hook" ]
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 40Mi
         - name: node-driver-registrar
-          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.13.0-eks-1-33-3
+          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.13.0-eks-1-33-9
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -95,8 +102,14 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.15.0-eks-1-33-3
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.15.0-eks-1-33-9
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
@@ -104,6 +117,12 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: plugin-dir
+          resources:
+            limits:
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
       volumes:
         - name: kubelet-dir
           hostPath:


### PR DESCRIPTION
**Context:**

- [x] value.yaml: adding default resources values to improve resource management

- [x]  value.yaml: adding security context, these security context settings are part of best practices for running containers securely in Kubernetes environments. They help to:
1. Minimize the potential impact of a compromised container
2. Prevent unauthorized changes to the container's filesystem
3. Limit the capabilities of processes running within the container

- [x] controller-deployment.yaml: adding more flexibility in specifying where to pull the container image from, which is useful for environments that use private registries or air-gapped setups. 

- [x] [new] pdb.yaml
- [x] value.yaml 
1. Added PodDisruptionBudget (PDB) for the FSx CSI controller to ensure high availability by limiting voluntary disruptions and maintaining minimum available replicas during cluster operations like node drains or upgrades.
2. It sets `maxUnavailable: 1` for deployments with 2 or fewer replicas, and `minAvailable: 2` for larger deployments, ensuring controller availability at all times.

**Is this a bug fix or adding new feature?**
New Feature