### PR TITLE
Fix: Add AL_VERSION default value in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ OUTPUT_TYPE?=docker
 OS?=linux
 ARCH?=amd64
 OSVERSION?=amazon
+AL_VERSION?=al23
 
 ALL_OS?=linux
 ALL_ARCH_linux?=amd64 arm64


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
Add AL_VERSION default value in Makefile

**What testing is done?** 
