### PR TITLE
Add support for --extra-tags to Helm chart

### DIFF
--- a/charts/aws-fsx-csi-driver/CHANGELOG.md
+++ b/charts/aws-fsx-csi-driver/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Helm chart
 
+# v1.12.1
+* Parameterize controller.extraTags
+
 # v1.12.0
 * Use driver image 1.5.0
 

--- a/charts/aws-fsx-csi-driver/Chart.yaml
+++ b/charts/aws-fsx-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.5.0"
 name: aws-fsx-csi-driver
 description: A Helm chart for AWS FSx for Lustre CSI Driver
-version: 1.12.0
+version: 1.12.1
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-fsx-csi-driver
 sources:

--- a/charts/aws-fsx-csi-driver/templates/_helpers.tpl
+++ b/charts/aws-fsx-csi-driver/templates/_helpers.tpl
@@ -54,3 +54,16 @@ app.kubernetes.io/name: {{ include "aws-fsx-csi-driver.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Prepare the `--extra-tags` controller flag from a map.
+*/}}
+{{- define "aws-fsx-csi-driver.extra-tags" -}}
+{{- $extraTags := list -}}
+{{- range $key, $value := .Values.controller.extraTags -}}
+{{- $extraTags = printf "%s=%v" $key $value | append $extraTags -}}
+{{- end -}}
+{{- if $extraTags -}}
+{{- printf "- \"--extra-tags=%s\"" (join "," $extraTags) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
@@ -44,6 +44,9 @@ spec:
           args:
             - --mode={{ .Values.controller.mode }}
             - --endpoint=$(CSI_ENDPOINT)
+            {{- if .Values.controller.extraTags }}
+              {{- include "aws-fsx-csi-driver.extra-tags" . | nindent 12 }}
+            {{- end }}
             - --logging-format={{ .Values.controller.loggingFormat }}
             - --v={{ .Values.controller.logLevel }}
           env:

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -138,6 +138,12 @@ controller:
     # Warning: Disabling PodDisruptionBudget may lead to delays in stateful workloads starting due to controller
     # pod restarts or evictions.
     enabled: true
+  # Extra tags to attach to each dynamically provisioned file system.
+  # ---
+  # extraTags:
+  #   key1: value1
+  #   key2: value2
+  extraTags: {}
 
 node:
   mode: node


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New feature.

**What is this PR about? / Why do we need it?**

Support configuring `--extra-tags` in the Helm chart, similar to https://github.com/kubernetes-sigs/aws-ebs-csi-driver/.

**What testing is done?** 

```bash
λ helm template charts/aws-fsx-csi-driver --set controller.extraTags.foo=bar | grep -A2 -B3 extra-tags
          args:
            - --mode=controller
            - --endpoint=$(CSI_ENDPOINT)
            - "--extra-tags=foo=bar"
            - --logging-format=text
            - --v=2
```

```bash
λ helm template charts/aws-fsx-csi-driver --set controller.extraTags.foo=bar --set controller.extraTags.baz=quux | grep -A2 -B3 extra-tags
          args:
            - --mode=controller
            - --endpoint=$(CSI_ENDPOINT)
            - "--extra-tags=baz=quux,foo=bar"
            - --logging-format=text
            - --v=2
```