### PR TITLE
Add podLabels parameter Original work by bueti in PR 416  and Allow timeout to be set Original work by coolstim in PR 435

### DIFF
--- a/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
@@ -19,6 +19,9 @@ spec:
       labels:
         app: fsx-csi-controller
         {{- include "aws-fsx-csi-driver.labels" . | nindent 8 }}
+        {{- if .Values.controller.podLabels }}
+          {{- toYaml .Values.controller.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
@@ -99,7 +99,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.sidecars.provisioner.logLevel }}
-            - --timeout=5m
+            - --timeout={{ .Values.controller.timeout| default "5m" }}
             - --extra-create-metadata
             - --leader-election=true
           env:

--- a/charts/aws-fsx-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-fsx-csi-driver/templates/node-daemonset.yaml
@@ -22,6 +22,9 @@ spec:
       labels:
         app: fsx-csi-node
         {{- include "aws-fsx-csi-driver.labels" . | nindent 8 }}
+        {{- if .Values.node.podLabels }}
+          {{- toYaml .Values.node.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -126,6 +126,7 @@ controller:
                 values:
                   - fargate
                   - hybrid
+  podLabels: {}
   # topologySpreadConstraints:
   #  - maxSkew: 1
   #    topologyKey: topology.kubernetes.io/zone
@@ -200,6 +201,7 @@ node:
             values:
             - fargate
             - hybrid
+  podLabels: {}
 
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -103,6 +103,8 @@ controller:
     - effect: NoExecute
       operator: Exists
       tolerationSeconds: 300
+  # Specify the timeout of all calls to the CSI driver.
+  timeout: 5m
   # securityContext on the controller pod
   securityContext:
     runAsNonRoot: false


### PR DESCRIPTION
## PodLabel 
Is this a bug fix or adding new feature?
This PR is adding a new feature - enabling users to specify custom pod labels for the FSx CSI driver controller and node components.

What is this PR about? / Why do we need it?
This PR enhances the AWS FSx CSI driver Helm chart by parameterizing pod labels for both the controller deployment and node daemonset. This allows users to add custom labels to the pods, which can be useful for:

Better pod identification and filtering in large clusters
Integration with monitoring, security, or compliance tools that rely on pod labels
Enabling organization-specific labeling standards
The implementation adds new configuration options (controller.podLabels and node.podLabels) to the values.yaml file, which are then applied to the respective pod template specs.

What testing is done?
The changes have been tested by:

Verifying that the chart installs successfully with default values
Testing the chart with custom pod labels specified for both controller and node components

## Timeout
Is this a bug fix or adding new feature?
This allows the configuration of a previously hard coded setting that controls the timeout of call to the csi driver.
https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/433

What is this PR about? / Why do we need it?
AWS had an issue taking the provisioning of file systems longer than the 5m default. Now this setting is configurable.

What testing is done?
Deployment with a timeout of 15m during the time that provisioning was taking longer than 5min.

## Attribution
This PR builds upon the work of:
- @bueti (Pod labels parameter - #416)
- @coolstim (Timeout configuration - #435)