### PR TITLE
Remove hybrid node exclusions

### DIFF
--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -127,7 +127,6 @@ controller:
                 operator: NotIn
                 values:
                   - fargate
-                  - hybrid
   podLabels: {}
   # topologySpreadConstraints:
   #  - maxSkew: 1
@@ -202,7 +201,6 @@ node:
             operator: NotIn
             values:
             - fargate
-            - hybrid
   podLabels: {}
 
 nameOverride: ""

--- a/deploy/kubernetes/base/controller-deployment.yaml
+++ b/deploy/kubernetes/base/controller-deployment.yaml
@@ -142,5 +142,4 @@ spec:
                 operator: NotIn
                 values:
                 - fargate
-                - hybrid
             weight: 1

--- a/deploy/kubernetes/base/node-daemonset.yaml
+++ b/deploy/kubernetes/base/node-daemonset.yaml
@@ -34,7 +34,6 @@ spec:
                 operator: NotIn
                 values:
                 - fargate
-                - hybrid
       containers:
         - name: fsx-plugin
           securityContext:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Adding new feature

**What is this PR about? / Why do we need it?**
This PR removes the hybrid node exclusions from the FSx CSI driver deployment configurations. Previously, the driver was configured to exclude hybrid nodes, which prevented it from running on these node types. By removing these exclusions, the FSx CSI driver can now be deployed on hybrid nodes, enabling FSx storage functionality for workloads running on these nodes. 

**What testing is done?** 
Manual testing by @junpengdev 



