### PR TITLE
Adding fixes for kops e2e test cluster name issue and bucket collisions

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -181,7 +181,7 @@ eval "EXPANDED_TEST_EXTRA_FLAGS=$TEST_EXTRA_FLAGS"
 set -x
 set +e
 pushd "${TEST_PATH}"
-${GINKGO_BIN} -timeout 24h -p -nodes="${GINKGO_NODES}" -v --focus="${GINKGO_FOCUS}" --skip="${GINKGO_SKIP}" ./... -- -kubeconfig="${KUBECONFIG}" -report-dir="${ARTIFACTS}" -gce-zone="${FIRST_ZONE}" "${EXPANDED_TEST_EXTRA_FLAGS}"
+${GINKGO_BIN} -timeout 24h -p -nodes="${GINKGO_NODES}" -v --focus="${GINKGO_FOCUS}" --skip="${GINKGO_SKIP}" ./... -- -kubeconfig="${KUBECONFIG}" -report-dir="${ARTIFACTS}" -gce-zone="${FIRST_ZONE}" --cluster-name="${CLUSTER_NAME}" "${EXPANDED_TEST_EXTRA_FLAGS}"
 TEST_PASSED=$?
 set -e
 set +x

--- a/tests/e2e/cloud.go
+++ b/tests/e2e/cloud.go
@@ -17,6 +17,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -86,10 +87,16 @@ func (c *cloud) createS3Bucket(name string, region string) error {
 
 	ctx := context.Background()
 	_, err := c.s3client.CreateBucket(ctx, request)
-	if err != nil {
-		return err
+	return err
+}
+
+func (c *cloud) isBucketAlreadyExistsError(err error) bool {
+	if err == nil {
+		return false
 	}
-	return nil
+	// Check if error message contains BucketAlreadyExists or BucketAlreadyOwnedByYou
+	errStr := err.Error()
+	return strings.Contains(errStr, "BucketAlreadyExists") || strings.Contains(errStr, "BucketAlreadyOwnedByYou")
 }
 
 func (c *cloud) deleteS3Bucket(name string) error {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix

**What is this PR about? / Why do we need it?**
This PR fixes two issues preventing e2e tests against kops from running successfully:

1. Cluster name not being passed to test suite, causing "no instances in cluster" errors
2. S3 bucket name collisions when running tests due to globally shared bucket namespace

#### Automatically pass cluster name to e2e tests (hack/e2e/run.sh)

Problem: The test suite requires --cluster-name to query EC2 instances, but the dynamically generated cluster name wasn't being passed through.

Solution: Modified the ginkgo invocation to automatically include --cluster-name="${CLUSTER_NAME}" flag.

#### Handle S3 bucket name collisions (tests/e2e/cloud.go, tests/e2e/dynamic_provisioning_test.go)

Problem: S3 bucket names are globally unique across all AWS accounts. The test suite used a simple naming scheme (fsx-e2e-{namespace}) that could collide with buckets created by other users or previous test runs, causing BucketAlreadyExists errors.

Solution: Implemented a backwards-compatible fallback strategy:

  1. First attempts to create bucket with original naming scheme (fsx-e2e-{namespace})
  2. If bucket already exists globally, retries with a timestamp suffix (fsx-e2e-{namespace}-{unix-timestamp})
  3. Added isBucketAlreadyExistsError() helper to detect bucket collision errors

**What testing is done?** 
make test

and

KOPS_STATE_FILE=s3://INSERT-BUCKET-NAME-HERE \
AWS_REGION=us-west-2 \
AWS_AVAILABILITY_ZONES=us-west-2a \
./hack/e2e/run.sh