### PR TITLE
Adding fixes for EKS e2e test cluster name issue, image, tags and permissions

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -181,7 +181,7 @@ eval "EXPANDED_TEST_EXTRA_FLAGS=$TEST_EXTRA_FLAGS"
 set -x
 set +e
 pushd "${TEST_PATH}"
-${GINKGO_BIN} -timeout 24h -p -nodes="${GINKGO_NODES}" -v --focus="${GINKGO_FOCUS}" --skip="${GINKGO_SKIP}" ./... -- -kubeconfig="${KUBECONFIG}" -report-dir="${ARTIFACTS}" -gce-zone="${FIRST_ZONE}" "${EXPANDED_TEST_EXTRA_FLAGS}"
+${GINKGO_BIN} -timeout 24h -p -nodes="${GINKGO_NODES}" -v --focus="${GINKGO_FOCUS}" --skip="${GINKGO_SKIP}" ./... -- -kubeconfig="${KUBECONFIG}" -report-dir="${ARTIFACTS}" -gce-zone="${FIRST_ZONE}" --cluster-name="${CLUSTER_NAME}" "${EXPANDED_TEST_EXTRA_FLAGS}"
 TEST_PASSED=$?
 set -e
 set +x

--- a/hack/eksctl-patch.yaml
+++ b/hack/eksctl-patch.yaml
@@ -1,0 +1,25 @@
+managedNodeGroups:
+- name: ng-1
+  amiFamily: AmazonLinux2023
+  iam:
+    attachPolicyARNs:
+    - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+    - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+    - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+    attachPolicy:
+      Version: "2012-10-17"
+      Statement:
+      - Effect: Allow
+        Action:
+        - iam:CreateServiceLinkedRole
+        - iam:AttachRolePolicy
+        - iam:PutRolePolicy
+        Resource: arn:aws:iam::*:role/aws-service-role/s3.data-source.lustre.fsx.amazonaws.com/*
+      - Effect: Allow
+        Action:
+        - s3:ListBucket
+        - fsx:CreateFileSystem
+        - fsx:DeleteFileSystem
+        - fsx:DescribeFileSystems
+        - fsx:TagResource
+        Resource: "*"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix

**What is this PR about? / Why do we need it?**
This PR fixes a number of issues preventing e2e tests against EKS from running successfully:

1. Cluster name not being passed to test suite, causing "no instances in cluster" errors
2. EC2 instance tag queries only looking for kops tags, not EKS tags
3. Missing IAM permissions for EKS node groups to create/manage FSx filesystems
4. EKS clusters not configured to use Amazon Linux 2023 as required by current EKS versions

#### Automatically pass cluster name to e2e tests (hack/e2e/run.sh)

Problem: The test suite requires --cluster-name to query EC2 instances, but the dynamically generated cluster name wasn't being passed through.

Solution: Modified the ginkgo invocation to automatically include --cluster-name="${CLUSTER_NAME}" flag.

####  Fix EC2 instance tag queries for EKS clusters (tests/e2e/cloud.go)

Problem: The original code only queried for the KubernetesCluster tag used by kops clusters. EKS clusters use a different tag (tag:eks:cluster-name), so the query would find zero instances when running against EKS.

Solution: Updated EC2 instance query to include both kops (tag:KubernetesCluster) and EKS (tag:eks:cluster-name) tag filters.

#### Add FSx IAM permissions to EKS node groups (hack/eksctl-patch.yaml)

Problem: EKS nodes didn't have the necessary IAM permissions to create and manage FSx filesystems.

Solution: Added inline IAM policy to eksctl patch file matching the permissions used in kops clusters.

#### Configure Amazon Linux 2023 for EKS node groups (hack/eksctl-patch.yaml)

Problem: EKS clusters were not explicitly configured with an AMI family, defaulting to the unsupported AL2 AMI.

Solution: Added amiFamily: AmazonLinux2023 to the eksctl patch configuration.

**What testing is done?** 

make test

and

CLUSTER_TYPE=eksctl \
AWS_REGION=us-west-2 \
AWS_AVAILABILITY_ZONES=us-west-2a,us-west-2b \
./hack/e2e/run.sh

Resolves #206 