### PR TITLE
Add support for API metrics in the FSx CSI Driver

### DIFF
--- a/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
+++ b/charts/aws-fsx-csi-driver/templates/controller-deployment.yaml
@@ -12,9 +12,15 @@ spec:
       {{- include "aws-fsx-csi-driver.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.controller.podAnnotations }}
+      {{- if or .Values.controller.podAnnotations (and .Values.controller.enableMetrics .Values.controller.enablePrometheusAnnotations) }}
       annotations:
+        {{- with .Values.controller.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if and .Values.controller.enableMetrics .Values.controller.enablePrometheusAnnotations }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "3301"
+        {{- end }}
       {{- end }}
       labels:
         app: fsx-csi-controller
@@ -52,6 +58,9 @@ spec:
             {{- end }}
             - --logging-format={{ .Values.controller.loggingFormat }}
             - --v={{ .Values.controller.logLevel }}
+            {{- if .Values.controller.enableMetrics }}
+            - --http-endpoint=0.0.0.0:3301
+            {{- end }}
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -82,6 +91,11 @@ spec:
             - name: healthz
               containerPort: 9910
               protocol: TCP
+            {{- if .Values.controller.enableMetrics }}
+            - name: metrics
+              containerPort: 3301
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/aws-fsx-csi-driver/templates/metrics.yaml
+++ b/charts/aws-fsx-csi-driver/templates/metrics.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.controller.enableMetrics }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fsx-csi-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: fsx-csi-controller
+    {{- include "aws-fsx-csi-driver.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: fsx-csi-controller
+    {{- include "aws-fsx-csi-driver.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: metrics
+      port: 3301
+      targetPort: 3301
+      protocol: TCP
+{{- if .Values.controller.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: fsx-csi-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: fsx-csi-controller
+    {{- include "aws-fsx-csi-driver.labels" . | nindent 4 }}
+spec:
+  endpoints:
+    - interval: 15s
+      path: /metrics
+      port: metrics
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: fsx-csi-controller
+{{- end }}
+{{- end }}

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -76,6 +76,15 @@ controller:
   loggingFormat: text
   nodeSelector: {}
   replicaCount: 2
+  # enableMetrics enables the Prometheus metrics endpoint on the controller.
+  # When true, the driver exposes metrics on port 3301.
+  enableMetrics: false
+  # enablePrometheusAnnotations adds prometheus.io scrape annotations to the controller pod.
+  enablePrometheusAnnotations: true
+  # serviceMonitor controls creation of Prometheus Operator ServiceMonitor resources.
+  # Requires the Prometheus Operator CRDs to be installed.
+  serviceMonitor:
+    enabled: false
   #If you do want to specify resources, uncomment the following lines, adjust them as necessary
   resources:
     requests:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/aws-fsx-csi-driver/pkg/driver"
+	"sigs.k8s.io/aws-fsx-csi-driver/pkg/metrics"
 )
 
 func main() {
@@ -33,6 +34,14 @@ func main() {
 	}
 
 	options := GetOptions(fs)
+
+	if options.ServerOptions.HTTPEndpoint != "" {
+		r := metrics.InitializeRecorder()
+		if options.ServerOptions.DriverMode == string(driver.ControllerMode) || options.ServerOptions.DriverMode == string(driver.AllMode) {
+			r.InitializeAPIMetrics()
+		}
+		r.InitializeMetricsHandler(options.ServerOptions.HTTPEndpoint, "/metrics", options.ServerOptions.MetricsCertFile, options.ServerOptions.MetricsKeyFile)
+	}
 
 	drv, err := driver.NewDriver(
 		driver.WithEndpoint(options.ServerOptions.Endpoint),

--- a/cmd/options/server_options.go
+++ b/cmd/options/server_options.go
@@ -28,11 +28,21 @@ type ServerOptions struct {
 	DriverMode string
 	// Endpoint is the endpoint that the driver server should listen on.
 	Endpoint string
+	// HTTPEndpoint is the TCP address for the Prometheus metrics HTTP server (e.g. :3301).
+	// An empty value disables metrics.
+	HTTPEndpoint string
+	// MetricsCertFile is the path to the TLS certificate for the metrics server.
+	MetricsCertFile string
+	// MetricsKeyFile is the path to the TLS private key for the metrics server.
+	MetricsKeyFile string
 }
 
 func (s *ServerOptions) AddFlags(fs *flag.FlagSet) string {
 	fs.StringVar(&s.DriverMode, "mode", driver.AllMode, "Service mode the driver server should run in")
 	fs.StringVar(&s.Endpoint, "endpoint", driver.DefaultCSIEndpoint, "Endpoint for the CSI driver server")
+	fs.StringVar(&s.HTTPEndpoint, "http-endpoint", "", "TCP network address for the Prometheus metrics HTTP server (e.g. 0.0.0.0:3301). An empty value disables metrics.")
+	fs.StringVar(&s.MetricsCertFile, "metrics-cert-file", "", "Path to the TLS certificate file for the metrics server. Requires --metrics-key-file.")
+	fs.StringVar(&s.MetricsKeyFile, "metrics-key-file", "", "Path to the TLS private key file for the metrics server. Requires --metrics-cert-file.")
 
 	return s.DriverMode
 }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,29 @@
+# Driver Metrics
+
+## Overview
+
+The FSx CSI Driver supports emitting metrics via an HTTP endpoint from the controller pod in the standard [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/). Most metrics systems support ingesting the Prometheus format, including [Prometheus](https://prometheus.io/), [CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-metrics.html), [InfluxDB](https://docs.influxdata.com/influxdb/v1/supported_protocols/prometheus/), and many others.
+
+When installing via Helm, metrics can be configured via Helm parameters:
+- Metrics may be enabled by setting `controller.enableMetrics` to `true`.
+  - This deploys a `Service` object for the controller pod.
+  - By default, the controller pod is annotated with `prometheus.io/scrape` and `prometheus.io/port`. This can be controlled via `controller.enablePrometheusAnnotations`.
+  - Prometheus Operator `ServiceMonitor` resources can be enabled by setting `controller.serviceMonitor.enabled` to `true`. This requires the Prometheus Operator CRDs to be installed.
+
+## AWS API Metrics (`fsx-csi-controller`)
+
+The FSx CSI Driver emits [AWS FSx API](https://docs.aws.amazon.com/fsx/latest/APIReference/Welcome.html) metrics to `0.0.0.0:3301/metrics` when `controller.enableMetrics: true` is set in the Helm chart.
+
+The following metrics are supported:
+
+| Metric name | Metric type | Description | Labels |
+|-------------|-------------|-------------|--------|
+| `aws_fsx_csi_api_request_duration_seconds` | Histogram | AWS SDK API request duration by request type in seconds | `request=<FSx API operation name>` |
+| `aws_fsx_csi_api_request_errors_total` | Counter | Total number of AWS SDK API errors by error code and request type | `request=<FSx API operation name>`, `code=<error code>` |
+| `aws_fsx_csi_api_request_throttles_total` | Counter | Total number of throttled AWS SDK API requests per request type | `request=<FSx API operation name>` |
+
+Instrumented FSx API operations: `CreateFileSystem`, `DeleteFileSystem`, `DescribeFileSystems`, `UpdateFileSystem`.
+
+## TLS
+
+The metrics endpoint can be served over TLS by providing `--metrics-cert-file` and `--metrics-key-file` flags to the driver.

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,16 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.3
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.15
 	github.com/aws/aws-sdk-go-v2/service/fsx v1.65.0
+	github.com/aws/smithy-go v1.24.0
 	github.com/container-storage-interface/spec v1.12.0
 	github.com/kubernetes-csi/csi-test v2.0.1+incompatible
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.38.2
+	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/mock v0.6.0
+	golang.org/x/time v0.14.0
 	google.golang.org/grpc v1.79.3
 	k8s.io/api v0.34.2
 	k8s.io/apimachinery v0.34.2
@@ -32,7 +35,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.11 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.3 // indirect
-	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -62,13 +64,13 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.4 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
@@ -86,7 +88,6 @@ require (
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/term v0.38.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -145,7 +145,9 @@ func NewCloud(region string) (Cloud, error) {
 	// Set RetryMaxAttempts to a high value. It will be "overwritten" if context deadline comes sooner.
 	awsConfig.RetryMaxAttempts = 8
 
-	svc := fsx.NewFromConfig(awsConfig)
+	svc := fsx.NewFromConfig(awsConfig, func(o *fsx.Options) {
+		o.APIOptions = append(o.APIOptions, RecordRequestsMiddleware(), LogServerErrorsMiddleware())
+	})
 	c := &cloud{
 		region:      region,
 		fsx:         svc,

--- a/pkg/cloud/handlers.go
+++ b/pkg/cloud/handlers.go
@@ -69,7 +69,7 @@ func LogServerErrorsMiddleware() func(*middleware.Stack) error {
 						if _, isThrottle := retry.DefaultThrottleErrorCodes[apiErr.ErrorCode()]; isThrottle {
 							klog.V(4).ErrorS(apiErr, "Throttle error from AWS API")
 						} else {
-							klog.V(3).ErrorS(apiErr, "Error from AWS API")
+							klog.ErrorS(apiErr, "Error from AWS API")
 						}
 					} else {
 						klog.ErrorS(err, "Unknown error attempting to contact AWS API")

--- a/pkg/cloud/handlers.go
+++ b/pkg/cloud/handlers.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/middleware"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/aws-fsx-csi-driver/pkg/metrics"
+)
+
+// RecordRequestsMiddleware instruments FSx API calls with Prometheus metrics.
+// It is a no-op when the metrics recorder is not initialized.
+func RecordRequestsMiddleware() func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Finalize.Add(middleware.FinalizeMiddlewareFunc("RecordRequestsMiddleware",
+			func(ctx context.Context, input middleware.FinalizeInput, next middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+				start := time.Now()
+				output, metadata, err := next.HandleFinalize(ctx, input)
+				duration := time.Since(start).Seconds()
+				labels := createLabels(ctx)
+				metrics.Recorder().ObserveHistogram(metrics.APIRequestDuration, metrics.APIRequestDurationHelpText, duration, labels, nil)
+				if err != nil {
+					var apiErr smithy.APIError
+					if errors.As(err, &apiErr) {
+						if _, isThrottle := retry.DefaultThrottleErrorCodes[apiErr.ErrorCode()]; isThrottle {
+							metrics.Recorder().IncreaseCount(metrics.APIRequestThrottles, metrics.APIRequestThrottlesHelpText, labels)
+						} else {
+							labels["code"] = apiErr.ErrorCode()
+							metrics.Recorder().IncreaseCount(metrics.APIRequestErrors, metrics.APIRequestErrorsHelpText, labels)
+						}
+					}
+				}
+				return output, metadata, err
+			}), middleware.After)
+	}
+}
+
+// LogServerErrorsMiddleware logs server errors and throttles received from the FSx API.
+// Throttle errors are logged at a higher verbosity to avoid flooding logs under normal bursty workloads.
+func LogServerErrorsMiddleware() func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Finalize.Add(middleware.FinalizeMiddlewareFunc("LogServerErrorsMiddleware",
+			func(ctx context.Context, input middleware.FinalizeInput, next middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+				output, metadata, err := next.HandleFinalize(ctx, input)
+				if err != nil {
+					var apiErr smithy.APIError
+					if errors.As(err, &apiErr) {
+						if _, isThrottle := retry.DefaultThrottleErrorCodes[apiErr.ErrorCode()]; isThrottle {
+							klog.V(4).ErrorS(apiErr, "Throttle error from AWS API")
+						} else {
+							klog.V(3).ErrorS(apiErr, "Error from AWS API")
+						}
+					} else {
+						klog.ErrorS(err, "Unknown error attempting to contact AWS API")
+					}
+				}
+				return output, metadata, err
+			}), middleware.After)
+	}
+}
+
+func createLabels(ctx context.Context) map[string]string {
+	op := awsmiddleware.GetOperationName(ctx)
+	if op == "" {
+		op = "Unknown"
+	}
+	return map[string]string{"request": op}
+}

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+const (
+	APIRequestDuration          = "aws_fsx_csi_api_request_duration_seconds"
+	APIRequestErrors            = "aws_fsx_csi_api_request_errors_total"
+	APIRequestThrottles         = "aws_fsx_csi_api_request_throttles_total"
+	APIRequestDurationHelpText  = "AWS SDK API request duration by request type in seconds"
+	APIRequestErrorsHelpText    = "Total number of AWS SDK API errors by error code and request type"
+	APIRequestThrottlesHelpText = "Total number of throttled AWS SDK API requests per request type"
+)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -97,9 +97,10 @@ func (m *MetricRecorder) InitializeMetricsHandler(address, path, certFile, keyFi
 	mux.Handle(path, rateLimitMiddleware(limiter, metricsHandler))
 
 	server := &http.Server{
-		Addr:        address,
-		Handler:     mux,
-		ReadTimeout: 3 * time.Second,
+		Addr:         address,
+		Handler:      mux,
+		ReadTimeout:  3 * time.Second,
+		WriteTimeout: 5 * time.Second,
 	}
 
 	go func() {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -47,7 +47,7 @@ var (
 
 // MetricRecorder holds a Prometheus registry and the registered metrics.
 type MetricRecorder struct {
-	mu       sync.Mutex
+	mu       sync.RWMutex
 	registry *prometheus.Registry
 	metrics  map[string]any
 }
@@ -126,14 +126,18 @@ func (m *MetricRecorder) IncreaseCount(name, helpText string, labels map[string]
 		return
 	}
 
-	m.mu.Lock()
+	m.mu.RLock()
 	metric, ok := m.metrics[name]
+	m.mu.RUnlock()
 	if !ok {
-		klog.V(4).InfoS("Metric not found, registering", "name", name, "labels", labels)
-		m.registerCounterVecLocked(name, helpText, getLabelNames(labels))
+		m.mu.Lock()
+		if _, exists := m.metrics[name]; !exists {
+			klog.V(4).InfoS("Metric not found, registering", "name", name, "labels", labels)
+			m.registerCounterVecLocked(name, helpText, getLabelNames(labels))
+		}
 		metric = m.metrics[name]
+		m.mu.Unlock()
 	}
-	m.mu.Unlock()
 
 	if cv, ok := metric.(*prometheus.CounterVec); ok {
 		cv.With(labels).Inc()
@@ -148,14 +152,18 @@ func (m *MetricRecorder) ObserveHistogram(name, helpText string, value float64, 
 		return
 	}
 
-	m.mu.Lock()
+	m.mu.RLock()
 	metric, ok := m.metrics[name]
+	m.mu.RUnlock()
 	if !ok {
-		klog.V(4).InfoS("Metric not found, registering", "name", name, "labels", labels)
-		m.registerHistogramVecLocked(name, helpText, getLabelNames(labels), buckets)
+		m.mu.Lock()
+		if _, exists := m.metrics[name]; !exists {
+			klog.V(4).InfoS("Metric not found, registering", "name", name, "labels", labels)
+			m.registerHistogramVecLocked(name, helpText, getLabelNames(labels), buckets)
+		}
 		metric = m.metrics[name]
+		m.mu.Unlock()
 	}
-	m.mu.Unlock()
 
 	if hv, ok := metric.(*prometheus.HistogramVec); ok {
 		hv.With(labels).Observe(value)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"golang.org/x/time/rate"
+	"k8s.io/klog/v2"
+)
+
+const (
+	metricsRateLimit = 5  // requests per second
+	metricsRateBurst = 10 // burst capacity
+)
+
+var (
+	r    *MetricRecorder
+	once sync.Once
+
+	fsxOperations = []string{
+		"CreateFileSystem",
+		"DeleteFileSystem",
+		"DescribeFileSystems",
+		"UpdateFileSystem",
+	}
+)
+
+// MetricRecorder holds a Prometheus registry and the registered metrics.
+type MetricRecorder struct {
+	mu       sync.Mutex
+	registry *prometheus.Registry
+	metrics  map[string]any
+}
+
+// Recorder returns the singleton MetricRecorder, or nil if metrics are not enabled.
+func Recorder() *MetricRecorder {
+	return r
+}
+
+// InitializeRecorder creates the singleton MetricRecorder and returns it.
+func InitializeRecorder() *MetricRecorder {
+	once.Do(func() {
+		r = &MetricRecorder{
+			registry: prometheus.NewRegistry(),
+			metrics:  make(map[string]any),
+		}
+	})
+	return r
+}
+
+func (m *MetricRecorder) initializeMetricWithOperations(name, help string, labelNames []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.metrics[name]; !exists {
+		metric := m.registerHistogramVecLocked(name, help, labelNames, nil)
+		for _, op := range fsxOperations {
+			metric.WithLabelValues(op)
+		}
+	}
+}
+
+// InitializeAPIMetrics pre-registers API metrics with all known FSx operation label values.
+func (m *MetricRecorder) InitializeAPIMetrics() {
+	m.initializeMetricWithOperations(APIRequestDuration, APIRequestDurationHelpText, []string{"request"})
+}
+
+// InitializeMetricsHandler starts a rate-limited HTTP server exposing Prometheus metrics.
+func (m *MetricRecorder) InitializeMetricsHandler(address, path, certFile, keyFile string) {
+	if m == nil {
+		klog.InfoS("InitializeMetricsHandler: metric recorder is not initialized")
+		return
+	}
+
+	limiter := rate.NewLimiter(metricsRateLimit, metricsRateBurst)
+	mux := http.NewServeMux()
+	metricsHandler := promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError})
+	mux.Handle(path, rateLimitMiddleware(limiter, metricsHandler))
+
+	server := &http.Server{
+		Addr:        address,
+		Handler:     mux,
+		ReadTimeout: 3 * time.Second,
+	}
+
+	go func() {
+		var err error
+		klog.InfoS("Metric server listening", "address", address, "path", path)
+
+		if certFile != "" {
+			err = server.ListenAndServeTLS(certFile, keyFile)
+		} else {
+			err = server.ListenAndServe()
+		}
+
+		if err != nil && err != http.ErrServerClosed {
+			klog.ErrorS(err, "Failed to start metric server", "address", address, "path", path)
+			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+		}
+	}()
+}
+
+// IncreaseCount increments the named counter metric by 1.
+func (m *MetricRecorder) IncreaseCount(name, helpText string, labels map[string]string) {
+	if m == nil {
+		return
+	}
+
+	m.mu.Lock()
+	metric, ok := m.metrics[name]
+	if !ok {
+		klog.V(4).InfoS("Metric not found, registering", "name", name, "labels", labels)
+		m.registerCounterVecLocked(name, helpText, getLabelNames(labels))
+		metric = m.metrics[name]
+	}
+	m.mu.Unlock()
+
+	if cv, ok := metric.(*prometheus.CounterVec); ok {
+		cv.With(labels).Inc()
+	} else {
+		klog.V(4).InfoS("Could not assert metric as CounterVec", "name", name)
+	}
+}
+
+// ObserveHistogram records value in the named histogram metric.
+func (m *MetricRecorder) ObserveHistogram(name, helpText string, value float64, labels map[string]string, buckets []float64) {
+	if m == nil {
+		return
+	}
+
+	m.mu.Lock()
+	metric, ok := m.metrics[name]
+	if !ok {
+		klog.V(4).InfoS("Metric not found, registering", "name", name, "labels", labels)
+		m.registerHistogramVecLocked(name, helpText, getLabelNames(labels), buckets)
+		metric = m.metrics[name]
+	}
+	m.mu.Unlock()
+
+	if hv, ok := metric.(*prometheus.HistogramVec); ok {
+		hv.With(labels).Observe(value)
+	} else {
+		klog.V(4).InfoS("Could not assert metric as HistogramVec", "name", name)
+	}
+}
+
+func rateLimitMiddleware(limiter *rate.Limiter, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !limiter.Allow() {
+			http.Error(w, "Rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// registerHistogramVecLocked registers a HistogramVec. Callers must hold m.mu.
+func (m *MetricRecorder) registerHistogramVecLocked(name, help string, labels []string, buckets []float64) *prometheus.HistogramVec {
+	if metric, exists := m.metrics[name]; exists {
+		if hv, ok := metric.(*prometheus.HistogramVec); ok {
+			return hv
+		}
+		klog.ErrorS(nil, "Metric exists but is not a HistogramVec", "name", name)
+		return nil
+	}
+	hv := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    name,
+		Help:    help,
+		Buckets: buckets,
+	}, labels)
+	m.metrics[name] = hv
+	m.registry.MustRegister(hv)
+	return hv
+}
+
+// registerCounterVecLocked registers a CounterVec. Callers must hold m.mu.
+func (m *MetricRecorder) registerCounterVecLocked(name, help string, labels []string) {
+	if _, exists := m.metrics[name]; exists {
+		return
+	}
+	cv := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: name,
+		Help: help,
+	}, labels)
+	m.metrics[name] = cv
+	m.registry.MustRegister(cv)
+}
+
+func getLabelNames(labels map[string]string) []string {
+	names := make([]string, 0, len(labels))
+	for k := range labels {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func newTestRecorder() *MetricRecorder {
+	return &MetricRecorder{
+		registry: prometheus.NewRegistry(),
+		metrics:  make(map[string]any),
+	}
+}
+
+func TestMetricRecorder(t *testing.T) {
+	tests := []struct {
+		name     string
+		exec     func(m *MetricRecorder)
+		expected string
+	}{
+		{
+			name: "TestMetricRecorder: IncreaseCounterMetric",
+			exec: func(m *MetricRecorder) {
+				m.IncreaseCount("test_total", "help text", map[string]string{"key": "value"})
+			},
+			expected: `
+# HELP test_total help text
+# TYPE test_total counter
+test_total{key="value"} 1
+			`,
+		},
+		{
+			name: "TestMetricRecorder: ObserveHistogramMetric",
+			exec: func(m *MetricRecorder) {
+				m.ObserveHistogram("test", "help text", 1.5, map[string]string{"key": "value"}, []float64{1, 2, 3})
+			},
+			expected: `
+# HELP test help text
+# TYPE test histogram
+test_bucket{key="value",le="1"} 0
+test_bucket{key="value",le="2"} 1
+test_bucket{key="value",le="3"} 1
+test_bucket{key="value",le="+Inf"} 1
+test_sum{key="value"} 1.5
+test_count{key="value"} 1
+			`,
+		},
+		{
+			name: "TestMetricRecorder: Re-register metric",
+			exec: func(m *MetricRecorder) {
+				m.IncreaseCount("test_re_register_total", "help text", map[string]string{"key": "value1"})
+				m.mu.Lock()
+				m.registerCounterVecLocked("test_re_register_total", "help text", []string{"key"})
+				m.mu.Unlock()
+				m.IncreaseCount("test_re_register_total", "help text", map[string]string{"key": "value1"})
+				m.IncreaseCount("test_re_register_total", "help text", map[string]string{"key": "value2"})
+			},
+			expected: `
+# HELP test_re_register_total help text
+# TYPE test_re_register_total counter
+test_re_register_total{key="value1"} 2
+test_re_register_total{key="value2"} 1
+			`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestRecorder()
+			tt.exec(m)
+			if err := testutil.GatherAndCompare(m.registry, strings.NewReader(tt.expected), getMetricNameFromExpected(tt.expected)); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func getMetricNameFromExpected(expected string) string {
+	lines := strings.SplitSeq(expected, "\n")
+	for line := range lines {
+		if strings.Contains(line, "{") {
+			return strings.Split(line, "{")[0]
+		}
+	}
+	return ""
+}

--- a/tests/sanity/sanity_test.go
+++ b/tests/sanity/sanity_test.go
@@ -41,6 +41,7 @@ func TestSanity(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	Expect(os.Setenv("CSI_NODE_NAME", "fake-node")).To(Succeed())
 	fsxDriver = driver.NewFakeDriver(endpoint)
 	go func() {
 		Expect(fsxDriver.Run()).NotTo(HaveOccurred())
@@ -53,12 +54,17 @@ var _ = AfterSuite(func() {
 })
 
 var _ = Describe("AWS FSx for Lustre CSI Driver", func() {
-	_ = os.MkdirAll("/tmp/csi", os.ModePerm)
 	config := &sanity.Config{
 		Address:        endpoint,
 		TargetPath:     mountPath,
 		StagingPath:    stagePath,
 		TestVolumeSize: 2000 * util.GiB,
+		CreateTargetDir: func(path string) (string, error) {
+			return path, os.MkdirAll(path, os.ModePerm)
+		},
+		CreateStagingDir: func(path string) (string, error) {
+			return path, os.MkdirAll(path, os.ModePerm)
+		},
 	}
 	sanity.GinkgoTest(config)
 })


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New feature

**What is this PR about? / Why do we need it?**

Per https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/492 this PR adds support for FSx API CSI Driver prometheus metrics. This helps driver operators gain better clarity on failure and monitor request latencies. As discussed in the Github issue, I tried to model the structure and implementation of this to closely track the [EBS CSI Driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver).

I added these ones to start:

| Metric name | Metric type | Description | Labels |
|-------------|-------------|-------------|--------|
| `aws_fsx_csi_api_request_duration_seconds` | Histogram | AWS SDK API request duration by request type in seconds | `request=<FSx API operation name>` |
| `aws_fsx_csi_api_request_errors_total` | Counter | Total number of AWS SDK API errors by error code and request type | `request=<FSx API operation name>`, `code=<error code>` |
| `aws_fsx_csi_api_request_throttles_total` | Counter | Total number of throttled AWS SDK API requests per request type | `request=<FSx API operation name>` |

This PR is just the driver metrics. We plan to follow up with the sidecar metrics in a different PR to scope this one down.

**What testing is done?** 

I tested this internally on Netflix's K8s platform.