### PR TITLE
Add Feature for Forceful unmount when Initial unmount hangs 

### DIFF
--- a/charts/aws-fsx-csi-driver/templates/node-daemonset.yaml
+++ b/charts/aws-fsx-csi-driver/templates/node-daemonset.yaml
@@ -68,6 +68,12 @@ spec:
             - --endpoint=$(CSI_ENDPOINT)
             - --logging-format={{ .Values.node.loggingFormat }}
             - --v={{ .Values.node.logLevel }}
+            {{- with .Values.node.forcefulUnmountTimeout }}
+            - --forceful-unmount-timeout={{ . }}
+            {{- end }}
+            {{- with .Values.node.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock

--- a/charts/aws-fsx-csi-driver/values.yaml
+++ b/charts/aws-fsx-csi-driver/values.yaml
@@ -152,6 +152,21 @@ node:
   loggingFormat: text
   logLevel: 2
   kubeletPath: /var/lib/kubelet
+  # How long NodeUnpublishVolume waits for a normal unmount before escalating to
+  # `umount -f`. While waiting, the driver periodically checks whether the target
+  # has stopped being a mount point, so a umount(8) that blocks in the kernel
+  # after the filesystem is already detached no longer holds the volume's
+  # in-flight lock forever. Must be at least 30s. Set to 0 to skip the normal
+  # unmount and force immediately. Unset (the default) disables the feature and
+  # preserves the plain blocking unmount.
+  # ---
+  # forcefulUnmountTimeout: 2m
+  forcefulUnmountTimeout: ""
+  # Additional arguments passed to the fsx-plugin container.
+  # ---
+  # extraArgs:
+  #   - --forceful-unmount-timeout=2m
+  extraArgs: []
   nodeSelector: {}
   updateStrategy: {}
   #If you do want to specify resources, uncomment the following lines, adjust them as necessary,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,6 +38,7 @@ func main() {
 		driver.WithEndpoint(options.ServerOptions.Endpoint),
 		driver.WithMode(options.ServerOptions.DriverMode),
 		driver.WithExtraTags(options.ControllerOptions.ExtraTags),
+		driver.WithForcefulUnmountTimeout(options.NodeOptions.ForcefulUnmountTimeout),
 	)
 
 	if err != nil {

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -18,16 +18,17 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	flag "github.com/spf13/pflag"
 	"k8s.io/component-base/featuregate"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
-	"os"
 	"sigs.k8s.io/aws-fsx-csi-driver/cmd/hooks"
 	"sigs.k8s.io/aws-fsx-csi-driver/cmd/options"
 	"sigs.k8s.io/aws-fsx-csi-driver/pkg/cloud"
 	"sigs.k8s.io/aws-fsx-csi-driver/pkg/driver"
-	"strings"
 )
 
 // Options is the combined set of options for all operating modes.
@@ -106,6 +107,11 @@ func GetOptions(fs *flag.FlagSet) *Options {
 
 	if err := fs.Parse(args); err != nil {
 		panic(err)
+	}
+
+	if err := nodeOptions.Validate(); err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid node option: %v\n", err)
+		os.Exit(1)
 	}
 
 	err = logsapi.ValidateAndApply(c, featureGate)

--- a/cmd/options/node_options.go
+++ b/cmd/options/node_options.go
@@ -17,23 +17,41 @@ limitations under the License.
 package options
 
 import (
+	"fmt"
 	"time"
 
 	flag "github.com/spf13/pflag"
 )
 
+// minForcefulUnmountTimeout is the smallest positive --forceful-unmount-timeout
+// accepted. A normal unmount of a busy network filesystem can legitimately take
+// tens of seconds, and escalating to umount -f before it has had a fair chance
+// risks tearing down a mount that was about to come down cleanly.
+const minForcefulUnmountTimeout = 30 * time.Second
+
 // NodeOptions contains options and configuration settings for the node service.
 type NodeOptions struct {
 	// ForcefulUnmountTimeout is the duration after which a hanging unmount will be
 	// retried with umount -f, while periodically checking if the mount point has
-	// already disappeared. Set to 0 to disable (default, preserves existing behavior).
+	// already disappeared. Negative disables the feature (default, preserves
+	// existing behavior); 0 skips the normal unmount entirely.
 	ForcefulUnmountTimeout time.Duration
 }
 
 func (o *NodeOptions) AddFlags(fs *flag.FlagSet) {
-	fs.DurationVar(&o.ForcefulUnmountTimeout, "forceful-unmount-timeout", 0,
-		"Duration to wait for a normal unmount before retrying with umount -f. "+
-			"During this period the mount point is polled every 5s; if it disappears "+
-			"the lock is released immediately even if the umount process has not exited. "+
-			"Set to 0 to disable (default).")
+	fs.DurationVar(&o.ForcefulUnmountTimeout, "forceful-unmount-timeout", -1,
+		"Controls forced unmount behavior. "+
+			"Set to a positive duration (at least 30s, e.g. 2m) to wait that long "+
+			"for a normal unmount before escalating to umount -f. "+
+			"Set to 0 to call umount -f directly (skip normal unmount). "+
+			"Set to a negative duration to disable forced unmount entirely (default).")
+}
+
+// Validate checks that NodeOptions values are within acceptable bounds.
+func (o *NodeOptions) Validate() error {
+	if o.ForcefulUnmountTimeout > 0 && o.ForcefulUnmountTimeout < minForcefulUnmountTimeout {
+		return fmt.Errorf("--forceful-unmount-timeout must be at least %v if positive (use 0 to force unmount immediately, or a negative value to disable), got %v",
+			minForcefulUnmountTimeout, o.ForcefulUnmountTimeout)
+	}
+	return nil
 }

--- a/cmd/options/node_options.go
+++ b/cmd/options/node_options.go
@@ -17,12 +17,23 @@ limitations under the License.
 package options
 
 import (
+	"time"
+
 	flag "github.com/spf13/pflag"
 )
 
 // NodeOptions contains options and configuration settings for the node service.
 type NodeOptions struct {
+	// ForcefulUnmountTimeout is the duration after which a hanging unmount will be
+	// retried with umount -f, while periodically checking if the mount point has
+	// already disappeared. Set to 0 to disable (default, preserves existing behavior).
+	ForcefulUnmountTimeout time.Duration
 }
 
 func (o *NodeOptions) AddFlags(fs *flag.FlagSet) {
+	fs.DurationVar(&o.ForcefulUnmountTimeout, "forceful-unmount-timeout", 0,
+		"Duration to wait for a normal unmount before retrying with umount -f. "+
+			"During this period the mount point is polled every 5s; if it disappears "+
+			"the lock is released immediately even if the umount process has not exited. "+
+			"Set to 0 to disable (default).")
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc"
@@ -53,9 +54,10 @@ type Driver struct {
 }
 
 type DriverOptions struct {
-	endpoint  string
-	mode      string
-	extraTags string
+	endpoint               string
+	mode                   string
+	extraTags              string
+	forcefulUnmountTimeout time.Duration
 }
 
 func NewDriver(options ...func(*DriverOptions)) (*Driver, error) {
@@ -149,5 +151,11 @@ func WithMode(mode string) func(*DriverOptions) {
 func WithExtraTags(extraTags string) func(*DriverOptions) {
 	return func(o *DriverOptions) {
 		o.extraTags = extraTags
+	}
+}
+
+func WithForcefulUnmountTimeout(timeout time.Duration) func(*DriverOptions) {
+	return func(o *DriverOptions) {
+		o.forcefulUnmountTimeout = timeout
 	}
 }

--- a/pkg/driver/fakes.go
+++ b/pkg/driver/fakes.go
@@ -17,15 +17,31 @@ limitations under the License.
 package driver
 
 import (
+	"time"
+
 	"k8s.io/mount-utils"
 	"sigs.k8s.io/aws-fsx-csi-driver/pkg/cloud"
 	"sigs.k8s.io/aws-fsx-csi-driver/pkg/driver/internal"
 )
 
+// fakeForceMounter adds UnmountWithForce to mount.FakeMounter, which does not
+// implement mount.MounterForceUnmounter upstream. Without it, NodeMounter's
+// delegating UnmountWithForce would always fail the type assertion in tests and
+// the forced-unmount path would be untestable.
+type fakeForceMounter struct {
+	*mount.FakeMounter
+}
+
+func (m *fakeForceMounter) UnmountWithForce(target string, _ time.Duration) error {
+	return m.Unmount(target)
+}
+
 func NewFakeMounter() Mounter {
 	return &NodeMounter{
-		Interface: &mount.FakeMounter{
-			MountPoints: []mount.MountPoint{},
+		Interface: &fakeForceMounter{
+			FakeMounter: &mount.FakeMounter{
+				MountPoints: []mount.MountPoint{},
+			},
 		},
 	}
 }
@@ -47,7 +63,7 @@ func NewFakeDriver(endpoint string) *Driver {
 		nodeService: nodeService{
 			mounter:       NewFakeMounter(),
 			inFlight:      internal.NewInFlight(),
-			driverOptions: &DriverOptions{},
+			driverOptions: &DriverOptions{forcefulUnmountTimeout: -1},
 		},
 	}
 	return driver

--- a/pkg/driver/mocks/mock_mount.go
+++ b/pkg/driver/mocks/mock_mount.go
@@ -11,6 +11,7 @@ package mocks
 
 import (
 	reflect "reflect"
+	time "time"
 
 	gomock "go.uber.org/mock/gomock"
 	mount "k8s.io/mount-utils"
@@ -225,4 +226,18 @@ func (m *MockMounter) Unmount(target string) error {
 func (mr *MockMounterMockRecorder) Unmount(target any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unmount", reflect.TypeOf((*MockMounter)(nil).Unmount), target)
+}
+
+// UnmountWithForce mocks base method.
+func (m *MockMounter) UnmountWithForce(target string, umountTimeout time.Duration) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnmountWithForce", target, umountTimeout)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnmountWithForce indicates an expected call of UnmountWithForce.
+func (mr *MockMounterMockRecorder) UnmountWithForce(target, umountTimeout any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmountWithForce", reflect.TypeOf((*MockMounter)(nil).UnmountWithForce), target, umountTimeout)
 }

--- a/pkg/driver/mount.go
+++ b/pkg/driver/mount.go
@@ -17,8 +17,10 @@ limitations under the License.
 package driver
 
 import (
+	"fmt"
 	"k8s.io/mount-utils"
 	"os"
+	"time"
 )
 
 // Mounter is an interface for mount operations
@@ -27,6 +29,9 @@ type Mounter interface {
 	IsCorruptedMnt(err error) bool
 	PathExists(path string) (bool, error)
 	MakeDir(pathname string) error
+	// UnmountWithForce unmounts target, escalating to a forced unmount if the
+	// normal unmount has not returned within umountTimeout.
+	UnmountWithForce(target string, umountTimeout time.Duration) error
 }
 
 type NodeMounter struct {
@@ -52,6 +57,18 @@ func (m *NodeMounter) MakeDir(pathname string) error {
 // IsCorruptedMnt return true if err is about corrupted mount point
 func (m *NodeMounter) IsCorruptedMnt(err error) bool {
 	return mount.IsCorruptedMnt(err)
+}
+
+// UnmountWithForce unmounts given target but will retry unmounting with force
+// option after given timeout. Embedding mount.Interface only promotes the
+// methods declared on that interface, not the extra methods of the concrete
+// mounter it wraps, so this delegates explicitly.
+func (m *NodeMounter) UnmountWithForce(target string, umountTimeout time.Duration) error {
+	forceUnmounter, ok := m.Interface.(mount.MounterForceUnmounter)
+	if !ok {
+		return fmt.Errorf("mounter does not support forced unmount")
+	}
+	return forceUnmounter.UnmountWithForce(target, umountTimeout)
 }
 
 func (m *NodeMounter) PathExists(path string) (bool, error) {

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/mount-utils"
 	"sigs.k8s.io/aws-fsx-csi-driver/pkg/cloud"
 	"sigs.k8s.io/aws-fsx-csi-driver/pkg/driver/internal"
 	"sigs.k8s.io/aws-fsx-csi-driver/pkg/util"
@@ -263,19 +262,44 @@ func (d *nodeService) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest
 	}, nil
 }
 
-// unmount performs an unmount of the given target path. If forcefulUnmountTimeout
-// is configured, it runs the unmount in a goroutine and polls IsLikelyNotMountPoint
-// every 5 seconds. If the mount point disappears before the process exits, it
-// returns success immediately (the kernel-level work is done even if the umount
-// process is still cleaning up). If the timeout elapses and the mount point is
-// still present, it retries with umount -f via UnmountWithForce.
-// When forcefulUnmountTimeout is zero, it falls back to a plain blocking Unmount.
+// unmountPollInterval is how often unmount re-checks whether the target stopped
+// being a mount point while a normal unmount is still in flight. The umount(8)
+// child can block in the kernel long after the filesystem has actually been
+// detached, so polling is what lets us release the per-volume in-flight lock
+// instead of waiting on a process that may never exit.
+//
+// A var rather than a const so tests can shorten it.
+var unmountPollInterval = 5 * time.Second
+
+// unmount performs an unmount of the given target path.
+//   - forcefulUnmountTimeout == 0: skip normal unmount entirely and run umount -f
+//     directly. Use this to verify that force unmount works end-to-end.
+//   - forcefulUnmountTimeout > 0: run normal unmount in a goroutine, poll to see
+//     if the mount point disappeared, and escalate to umount -f if the timeout
+//     elapses.
+//   - forcefulUnmountTimeout < 0 (feature disabled): plain blocking Unmount.
+//
+// Every path is bounded: unmount never blocks its caller on a syscall that has
+// no timeout, because the caller holds the per-volume in-flight lock and a
+// permanent block there wedges the volume for the lifetime of the driver pod.
 func (d *nodeService) unmount(target string) error {
-	if d.driverOptions.forcefulUnmountTimeout == 0 {
+	timeout := d.driverOptions.forcefulUnmountTimeout
+
+	if timeout < 0 {
 		return d.mounter.Unmount(target)
 	}
 
-	const pollInterval = 5 * time.Second
+	if timeout == 0 {
+		klog.InfoS("NodeUnpublishVolume: forceful-unmount-timeout=0, going straight to forced unmount", "target", target)
+		// A zero umountTimeout makes UnmountWithForce's internal normal-unmount
+		// attempt expire immediately, so it escalates straight to umount -f.
+		return d.forceUnmount(target, 0, unmountPollInterval)
+	}
+
+	// The mount point may already be gone; skip the goroutine and the wait.
+	if d.targetUnmounted(target) {
+		return nil
+	}
 
 	// Run the normal unmount in the background; it may hang.
 	done := make(chan error, 1)
@@ -283,40 +307,81 @@ func (d *nodeService) unmount(target string) error {
 		done <- d.mounter.Unmount(target)
 	}()
 
-	ticker := time.NewTicker(pollInterval)
+	ticker := time.NewTicker(unmountPollInterval)
 	defer ticker.Stop()
-	timer := time.NewTimer(d.driverOptions.forcefulUnmountTimeout)
+	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 
 	for {
 		select {
 		case err := <-done:
-			// umount process exited on its own.
 			return err
 
 		case <-ticker.C:
-			// Check whether the mount point has already disappeared.
-			notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
-			if err == nil && notMnt {
-				// Kernel-level unmount is complete. The umount process may still
-				// be hanging in userspace cleanup, but the work is done — it is
-				// safe to release the lock now.
-				klog.V(4).InfoS("NodeUnpublishVolume: mount point gone before umount process exited, treating as success", "target", target)
+			if d.targetUnmounted(target) {
 				return nil
 			}
 
 		case <-timer.C:
-			// Timeout elapsed and mount point is still present. Fall back to
-			// umount -f to force the unmount.
-			klog.InfoS("NodeUnpublishVolume: unmount timed out, retrying with forced unmount", "target", target, "timeout", d.driverOptions.forcefulUnmountTimeout)
-			forceUnmounter, ok := d.mounter.(mount.MounterForceUnmounter)
-			if !ok {
-				return fmt.Errorf("unmount of %q timed out after %v and mounter does not support forced unmount", target, d.driverOptions.forcefulUnmountTimeout)
-			}
-			// UnmountWithForce uses exec.CommandContext internally so it will
-			// not block indefinitely.
-			return forceUnmounter.UnmountWithForce(target, d.driverOptions.forcefulUnmountTimeout)
+			klog.InfoS("NodeUnpublishVolume: unmount timed out, retrying with forced unmount", "target", target, "timeout", timeout)
+			return d.forceUnmount(target, timeout, timeout)
 		}
+	}
+}
+
+// targetUnmounted reports whether target has stopped being a mount point, either
+// because it was unmounted or because the directory itself is gone. A missing
+// target is success: kubelet removes the target directory after a successful
+// NodeUnpublishVolume, and some filesystems (Lustre among them) tear down the
+// mount namespace entry before the umount syscall returns.
+func (d *nodeService) targetUnmounted(target string) bool {
+	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
+	if err == nil && notMnt {
+		klog.V(4).InfoS("NodeUnpublishVolume: target is no longer a mount point, treating unmount as successful", "target", target)
+		return true
+	}
+	// IsLikelyNotMountPoint stats the path, so a vanished target surfaces as
+	// (true, ENOENT) rather than (true, nil). Log this louder than the plain
+	// case: the directory disappearing out from under us is unusual.
+	if os.IsNotExist(err) {
+		klog.InfoS("NodeUnpublishVolume: target path no longer exists, treating unmount as successful", "target", target)
+		return true
+	}
+	return false
+}
+
+// forceUnmount runs mounter.UnmountWithForce, which upstream implements with an
+// uninterruptible exec.Command("umount", "-f", ...) — no context, no deadline.
+// The whole point of this code path is that umount can block forever, so we run
+// it in its own goroutine and give up waiting after graceTimeout. The goroutine
+// (and its umount child) is deliberately left running: it may still succeed, and
+// abandoning it is what lets the caller release the per-volume lock so kubelet
+// can retry instead of the volume staying wedged.
+func (d *nodeService) forceUnmount(target string, umountTimeout, graceTimeout time.Duration) error {
+	done := make(chan error, 1)
+	go func() {
+		done <- d.mounter.UnmountWithForce(target, umountTimeout)
+	}()
+
+	timer := time.NewTimer(graceTimeout)
+	defer timer.Stop()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			klog.ErrorS(err, "NodeUnpublishVolume: forced unmount failed", "target", target)
+			return err
+		}
+		klog.InfoS("NodeUnpublishVolume: forced unmount succeeded", "target", target)
+		return nil
+
+	case <-timer.C:
+		// Check once more: the filesystem may be detached even though umount has
+		// not returned.
+		if d.targetUnmounted(target) {
+			return nil
+		}
+		return fmt.Errorf("forced unmount of %q did not complete within %v; abandoning it so the volume is not held indefinitely", target, graceTimeout)
 	}
 }
 
@@ -336,7 +401,11 @@ func (d *nodeService) isMounted(_ string, target string) (bool, error) {
 		_, pathErr := d.mounter.PathExists(target)
 		if pathErr != nil && d.mounter.IsCorruptedMnt(pathErr) {
 			klog.V(4).InfoS("NodePublishVolume: Target path is a corrupted mount. Trying to unmount.", "target", target)
-			if mntErr := d.mounter.Unmount(target); mntErr != nil {
+			// Go through d.unmount, not mounter.Unmount: this runs while the
+			// publish in-flight lock is held, so it needs the same timeout and
+			// forced-unmount escalation that NodeUnpublishVolume gets. A corrupted
+			// mount is exactly the case where a bare unmount is liable to hang.
+			if mntErr := d.unmount(target); mntErr != nil {
 				return false, status.Errorf(codes.Internal, "Unable to unmount the target %q : %v", target, mntErr)
 			}
 			//After successful unmount, the device is ready to be mounted.

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/mount-utils"
 	"sigs.k8s.io/aws-fsx-csi-driver/pkg/cloud"
 	"sigs.k8s.io/aws-fsx-csi-driver/pkg/driver/internal"
 	"sigs.k8s.io/aws-fsx-csi-driver/pkg/util"
@@ -213,8 +214,7 @@ func (d *nodeService) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	}
 
 	klog.V(5).InfoS("NodeUnpublishVolume: unmounting", "target", target)
-	err := d.mounter.Unmount(target)
-	if err != nil {
+	if err := d.unmount(target); err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not unmount %q: %v", target, err)
 	}
 
@@ -261,6 +261,63 @@ func (d *nodeService) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest
 	return &csi.NodeGetInfoResponse{
 		NodeId: metadata.GetInstanceID(),
 	}, nil
+}
+
+// unmount performs an unmount of the given target path. If forcefulUnmountTimeout
+// is configured, it runs the unmount in a goroutine and polls IsLikelyNotMountPoint
+// every 5 seconds. If the mount point disappears before the process exits, it
+// returns success immediately (the kernel-level work is done even if the umount
+// process is still cleaning up). If the timeout elapses and the mount point is
+// still present, it retries with umount -f via UnmountWithForce.
+// When forcefulUnmountTimeout is zero, it falls back to a plain blocking Unmount.
+func (d *nodeService) unmount(target string) error {
+	if d.driverOptions.forcefulUnmountTimeout == 0 {
+		return d.mounter.Unmount(target)
+	}
+
+	const pollInterval = 5 * time.Second
+
+	// Run the normal unmount in the background; it may hang.
+	done := make(chan error, 1)
+	go func() {
+		done <- d.mounter.Unmount(target)
+	}()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	timer := time.NewTimer(d.driverOptions.forcefulUnmountTimeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case err := <-done:
+			// umount process exited on its own.
+			return err
+
+		case <-ticker.C:
+			// Check whether the mount point has already disappeared.
+			notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
+			if err == nil && notMnt {
+				// Kernel-level unmount is complete. The umount process may still
+				// be hanging in userspace cleanup, but the work is done — it is
+				// safe to release the lock now.
+				klog.V(4).InfoS("NodeUnpublishVolume: mount point gone before umount process exited, treating as success", "target", target)
+				return nil
+			}
+
+		case <-timer.C:
+			// Timeout elapsed and mount point is still present. Fall back to
+			// umount -f to force the unmount.
+			klog.InfoS("NodeUnpublishVolume: unmount timed out, retrying with forced unmount", "target", target, "timeout", d.driverOptions.forcefulUnmountTimeout)
+			forceUnmounter, ok := d.mounter.(mount.MounterForceUnmounter)
+			if !ok {
+				return fmt.Errorf("unmount of %q timed out after %v and mounter does not support forced unmount", target, d.driverOptions.forcefulUnmountTimeout)
+			}
+			// UnmountWithForce uses exec.CommandContext internally so it will
+			// not block indefinitely.
+			return forceUnmounter.UnmountWithForce(target, d.driverOptions.forcefulUnmountTimeout)
+		}
+	}
 }
 
 // isMounted checks if target is mounted. It does NOT return an error if target

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -19,8 +19,10 @@ package driver
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/stretchr/testify/assert"
@@ -517,8 +519,9 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				mockMounter := driverMocks.NewMockMounter(mockCtl)
 
 				driver := &nodeService{
-					mounter:  mockMounter,
-					inFlight: internal.NewInFlight(),
+					mounter:       mockMounter,
+					inFlight:      internal.NewInFlight(),
+					driverOptions: &DriverOptions{forcefulUnmountTimeout: -1},
 				}
 
 				ctx := context.Background()
@@ -596,8 +599,9 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				mockMounter := driverMocks.NewMockMounter(mockCtl)
 
 				driver := &nodeService{
-					mounter:  mockMounter,
-					inFlight: internal.NewInFlight(),
+					mounter:       mockMounter,
+					inFlight:      internal.NewInFlight(),
+					driverOptions: &DriverOptions{forcefulUnmountTimeout: -1},
 				}
 
 				ctx := context.Background()
@@ -650,8 +654,9 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				mockMounter := driverMocks.NewMockMounter(mockCtl)
 
 				awsDriver := &nodeService{
-					mounter:  mockMounter,
-					inFlight: internal.NewInFlight(),
+					mounter:       mockMounter,
+					inFlight:      internal.NewInFlight(),
+					driverOptions: &DriverOptions{forcefulUnmountTimeout: -1},
 				}
 
 				ctx := context.Background()
@@ -669,6 +674,225 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				_, err := awsDriver.NodeUnpublishVolume(ctx, req)
 				if err != nil {
 					t.Fatalf("NodeUnpublishVolume is failed: %v", err)
+				}
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, tc.testFunc)
+	}
+}
+
+// TestNodeUnpublishVolumeForcefulUnmount covers the forceful-unmount paths. The
+// bug being guarded against is a umount(8) that never returns: because
+// NodeUnpublishVolume holds a per-volume in-flight lock for its whole duration, a
+// permanently blocked unmount wedges the volume until the driver pod restarts. So
+// each case asserts the RPC *returns* rather than only what it returns.
+func TestNodeUnpublishVolumeForcefulUnmount(t *testing.T) {
+	const targetPath = "/target/path"
+
+	// Keep polling fast so the tests do not sit through real intervals.
+	origPollInterval := unmountPollInterval
+	unmountPollInterval = 10 * time.Millisecond
+	defer func() { unmountPollInterval = origPollInterval }()
+
+	// unpublish runs NodeUnpublishVolume and fails the test if it blocks, which is
+	// exactly the symptom customers hit.
+	unpublish := func(t *testing.T, driver *nodeService) error {
+		t.Helper()
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := driver.NodeUnpublishVolume(context.Background(), &csi.NodeUnpublishVolumeRequest{
+				VolumeId:   "volumeId",
+				TargetPath: targetPath,
+			})
+			errCh <- err
+		}()
+		select {
+		case err := <-errCh:
+			return err
+		case <-time.After(30 * time.Second):
+			t.Fatal("NodeUnpublishVolume did not return; the in-flight lock would be held indefinitely")
+			return nil
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		testFunc func(t *testing.T)
+	}{
+		{
+			// forceful-unmount-timeout=0 skips the normal unmount entirely.
+			name: "success: timeout zero forces unmount immediately",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMounter := driverMocks.NewMockMounter(mockCtl)
+				driver := &nodeService{
+					mounter:       mockMounter,
+					inFlight:      internal.NewInFlight(),
+					driverOptions: &DriverOptions{forcefulUnmountTimeout: 0},
+				}
+
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(targetPath)).Return(false, nil)
+				mockMounter.EXPECT().UnmountWithForce(gomock.Eq(targetPath), gomock.Eq(time.Duration(0))).Return(nil)
+				// No plain Unmount: gomock fails the test if one is attempted.
+
+				if err := unpublish(t, driver); err != nil {
+					t.Fatalf("NodeUnpublishVolume failed: %v", err)
+				}
+			},
+		},
+		{
+			// The regression this whole change exists for: the normal unmount never
+			// returns, but the mount point is gone, so polling must notice and let the
+			// RPC finish instead of blocking on the stuck umount forever.
+			name: "success: hanging unmount released when mount point disappears",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMounter := driverMocks.NewMockMounter(mockCtl)
+				driver := &nodeService{
+					mounter:       mockMounter,
+					inFlight:      internal.NewInFlight(),
+					driverOptions: &DriverOptions{forcefulUnmountTimeout: 10 * time.Second},
+				}
+
+				// Mounted at entry and on the first poll, unmounted on later polls.
+				gomock.InOrder(
+					mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(targetPath)).Return(false, nil).Times(2),
+					mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(targetPath)).Return(true, nil).MinTimes(1),
+				)
+				// Unmount never returns, mimicking a umount blocked in the kernel.
+				mockMounter.EXPECT().Unmount(gomock.Eq(targetPath)).DoAndReturn(func(string) error {
+					<-make(chan struct{})
+					return nil
+				})
+
+				if err := unpublish(t, driver); err != nil {
+					t.Fatalf("NodeUnpublishVolume failed: %v", err)
+				}
+			},
+		},
+		{
+			// IsLikelyNotMountPoint stats the path, so a target removed by kubelet (or
+			// by a filesystem that drops the namespace entry before umount returns)
+			// reports (true, ENOENT), not (true, nil). Treating that as still-mounted
+			// is what made the poll loop useless.
+			name: "success: hanging unmount released when target path vanishes",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMounter := driverMocks.NewMockMounter(mockCtl)
+				driver := &nodeService{
+					mounter:       mockMounter,
+					inFlight:      internal.NewInFlight(),
+					driverOptions: &DriverOptions{forcefulUnmountTimeout: 10 * time.Second},
+				}
+
+				gomock.InOrder(
+					mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(targetPath)).Return(false, nil).Times(2),
+					mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(targetPath)).
+						Return(true, os.ErrNotExist).MinTimes(1),
+				)
+				mockMounter.EXPECT().Unmount(gomock.Eq(targetPath)).DoAndReturn(func(string) error {
+					<-make(chan struct{})
+					return nil
+				})
+
+				if err := unpublish(t, driver); err != nil {
+					t.Fatalf("NodeUnpublishVolume failed: %v", err)
+				}
+			},
+		},
+		{
+			// Still mounted and unmount still stuck: escalate to umount -f.
+			name: "success: hanging unmount escalates to forced unmount",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMounter := driverMocks.NewMockMounter(mockCtl)
+				timeout := 50 * time.Millisecond
+				driver := &nodeService{
+					mounter:       mockMounter,
+					inFlight:      internal.NewInFlight(),
+					driverOptions: &DriverOptions{forcefulUnmountTimeout: timeout},
+				}
+
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(targetPath)).Return(false, nil).AnyTimes()
+				mockMounter.EXPECT().Unmount(gomock.Eq(targetPath)).DoAndReturn(func(string) error {
+					<-make(chan struct{})
+					return nil
+				})
+				mockMounter.EXPECT().UnmountWithForce(gomock.Eq(targetPath), gomock.Eq(timeout)).Return(nil)
+
+				if err := unpublish(t, driver); err != nil {
+					t.Fatalf("NodeUnpublishVolume failed: %v", err)
+				}
+			},
+		},
+		{
+			// umount -f has no timeout upstream, so it can hang too. When it does, the
+			// RPC must still return an error rather than hold the lock, letting kubelet
+			// retry.
+			name: "fail: hanging forced unmount is abandoned instead of held",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMounter := driverMocks.NewMockMounter(mockCtl)
+				timeout := 50 * time.Millisecond
+				driver := &nodeService{
+					mounter:       mockMounter,
+					inFlight:      internal.NewInFlight(),
+					driverOptions: &DriverOptions{forcefulUnmountTimeout: timeout},
+				}
+
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(targetPath)).Return(false, nil).AnyTimes()
+				mockMounter.EXPECT().Unmount(gomock.Eq(targetPath)).DoAndReturn(func(string) error {
+					<-make(chan struct{})
+					return nil
+				})
+				mockMounter.EXPECT().UnmountWithForce(gomock.Eq(targetPath), gomock.Any()).
+					DoAndReturn(func(string, time.Duration) error {
+						<-make(chan struct{})
+						return nil
+					})
+
+				if err := unpublish(t, driver); err == nil {
+					t.Fatal("NodeUnpublishVolume succeeded despite a forced unmount that never returned")
+				}
+
+				// The lock must be free so kubelet's retry is not rejected with Aborted.
+				rpcKey := fmt.Sprintf("%s-%s", "volumeId", targetPath)
+				if ok := driver.inFlight.Insert(rpcKey); !ok {
+					t.Fatal("in-flight lock still held after NodeUnpublishVolume returned")
+				}
+			},
+		},
+		{
+			// Feature disabled: behavior must be byte-for-byte the old blocking path.
+			name: "success: negative timeout uses plain blocking unmount",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				defer mockCtl.Finish()
+
+				mockMounter := driverMocks.NewMockMounter(mockCtl)
+				driver := &nodeService{
+					mounter:       mockMounter,
+					inFlight:      internal.NewInFlight(),
+					driverOptions: &DriverOptions{forcefulUnmountTimeout: -1},
+				}
+
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(targetPath)).Return(false, nil)
+				mockMounter.EXPECT().Unmount(gomock.Eq(targetPath)).Return(nil)
+
+				if err := unpublish(t, driver); err != nil {
+					t.Fatalf("NodeUnpublishVolume failed: %v", err)
 				}
 			},
 		},


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
A new feature
**What is this PR about? / Why do we need it?**
Add a feature for forceful unmount to prevent hanging unmount command. 
**What testing is done?** 
