### PR TITLE
Use idempotency token + FS cache for createVolume

### DIFF
--- a/hack/e2e/cleanup-old-filesystems.sh
+++ b/hack/e2e/cleanup-old-filesystems.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Cleans up FSx Lustre filesystems older than a specified age.
+# This prevents stranded filesystems from e2e test failures from accumulating
+# and exhausting the account's FSx storage quota.
+
+set -euo pipefail
+
+REGION=${AWS_REGION:-us-west-2}
+MAX_AGE_DAYS=${MAX_AGE_DAYS:-7}
+
+echo "Cleaning up FSx Lustre filesystems older than ${MAX_AGE_DAYS} days in ${REGION}"
+
+CUTOFF_EPOCH=$(( $(date +%s) - (MAX_AGE_DAYS * 86400) ))
+
+# Get all Lustre filesystem IDs and creation times
+FS_LIST=$(aws fsx describe-file-systems \
+  --region "${REGION}" \
+  --output json \
+  --query 'FileSystems[?FileSystemType==`LUSTRE`].{Id:FileSystemId,Created:CreationTime,Capacity:StorageCapacity,Lifecycle:Lifecycle}')
+
+if [[ -z "${FS_LIST}" || "${FS_LIST}" == "[]" || "${FS_LIST}" == "null" ]]; then
+  echo "No Lustre filesystems found"
+  exit 0
+fi
+
+TOTAL=$(echo "${FS_LIST}" | jq length)
+echo "Found ${TOTAL} Lustre filesystem(s)"
+
+DELETED=0
+SKIPPED=0
+
+for row in $(echo "${FS_LIST}" | jq -r '.[] | @base64'); do
+  _jq() {
+    echo "${row}" | base64 --decode | jq -r "${1}"
+  }
+
+  FS_ID=$(_jq '.Id')
+  CREATION_TIME=$(_jq '.Created')
+  CAPACITY=$(_jq '.Capacity')
+  LIFECYCLE=$(_jq '.Lifecycle')
+
+  # FSx API returns creation time as Unix epoch float (e.g., 1754330438.291)
+  # Truncate to integer for comparison
+  FS_EPOCH=${CREATION_TIME%.*}
+
+  if [[ "${FS_EPOCH}" -lt "${CUTOFF_EPOCH}" ]]; then
+    AGE_DAYS=$(( ($(date +%s) - FS_EPOCH) / 86400 ))
+    echo "  DELETE ${FS_ID}: ${AGE_DAYS} days old, ${CAPACITY} GiB, lifecycle=${LIFECYCLE}"
+
+    if [[ "${LIFECYCLE}" == "DELETING" ]]; then
+      echo "    Already deleting, skipping"
+      SKIPPED=$((SKIPPED + 1))
+      continue
+    fi
+
+    aws fsx delete-file-system \
+      --region "${REGION}" \
+      --file-system-id "${FS_ID}" \
+      --output text > /dev/null 2>&1 || echo "    WARNING: failed to delete ${FS_ID}"
+
+    DELETED=$((DELETED + 1))
+  else
+    SKIPPED=$((SKIPPED + 1))
+  fi
+done
+
+echo "Cleanup complete. Deleted: ${DELETED}, Skipped: ${SKIPPED}"

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -106,6 +106,9 @@ if [[ ! -e ${GINKGO_BIN} ]]; then
   popd
 fi
 
+loudecho "Cleaning up old FSx filesystems"
+"${BASE_DIR}"/cleanup-old-filesystems.sh
+
 ecr_build_and_push "${REGION}" \
   "${AWS_ACCOUNT_ID}" \
   "${IMAGE_NAME}" \

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -46,8 +46,6 @@ const (
 	// creation time is around 5 minutes, and update time varies depending on
 	// target file system values
 	PollCheckTimeout = 10 * time.Minute
-	// CachePollInterval specifies the interval to poll for filesystem changes to update the cache
-	CachePollInterval = 1 * time.Minute
 )
 
 // Tags
@@ -123,14 +121,14 @@ type Cloud interface {
 	DescribeFileSystem(ctx context.Context, fileSystemId string) (fs *FileSystem, err error)
 	WaitForFileSystemAvailable(ctx context.Context, fileSystemId string) error
 	WaitForFileSystemResize(ctx context.Context, fileSystemId string, resizeGiB int32) error
-	FindFileSystemByVolumeName(ctx context.Context, volumeName string) (*FileSystem, error)
+	GetFileSystemIdByVolumeName(volumeName string) (string, bool)
 }
 
 type cloud struct {
-	region      string
-	fsx         FSx
-	volumeCache map[string]*FileSystem
-	cacheMutex  sync.RWMutex
+	region     string
+	fsx        FSx
+	fsIdCache  map[string]string
+	cacheMutex sync.RWMutex
 }
 
 // NewCloud returns a new instance of AWS cloud
@@ -149,11 +147,10 @@ func NewCloud(region string) (Cloud, error) {
 		o.APIOptions = append(o.APIOptions, RecordRequestsMiddleware(), LogServerErrorsMiddleware())
 	})
 	c := &cloud{
-		region:      region,
-		fsx:         svc,
-		volumeCache: make(map[string]*FileSystem),
+		region:    region,
+		fsx:       svc,
+		fsIdCache: make(map[string]string),
 	}
-	go c.pollFileSystems()
 	return c, nil
 }
 
@@ -283,9 +280,9 @@ func (c *cloud) CreateFileSystem(ctx context.Context, volumeName string, fileSys
 	}
 
 	c.cacheMutex.Lock()
-	c.volumeCache[volumeName] = fs
+	c.fsIdCache[volumeName] = fs.FileSystemId
 	c.cacheMutex.Unlock()
-	klog.V(4).InfoS("CreateFileSystem: added to cache", "volumeName", volumeName)
+	klog.V(4).InfoS("CreateFileSystem: cached filesystem ID", "volumeName", volumeName, "fileSystemId", fs.FileSystemId)
 
 	return fs, nil
 }
@@ -333,9 +330,9 @@ func (c *cloud) DeleteFileSystem(ctx context.Context, fileSystemId string) (err 
 
 	c.cacheMutex.Lock()
 	defer c.cacheMutex.Unlock()
-	for volName, fs := range c.volumeCache {
-		if fs.FileSystemId == fileSystemId {
-			delete(c.volumeCache, volName)
+	for volName, fsId := range c.fsIdCache {
+		if fsId == fileSystemId {
+			delete(c.fsIdCache, volName)
 			klog.V(4).InfoS("DeleteFileSystem: removed from cache", "volumeName", volName, "fileSystemId", fileSystemId)
 			break
 		}
@@ -475,87 +472,13 @@ func isBadRequestUpdateInProgress(err error) bool {
 	return errors.As(err, &badRequest) && strings.Contains(err.Error(), "Unable to perform the storage capacity update. There is an update already in progress.")
 }
 
-func (c *cloud) FindFileSystemByVolumeName(ctx context.Context, volumeName string) (*FileSystem, error) {
+func (c *cloud) GetFileSystemIdByVolumeName(volumeName string) (string, bool) {
 	c.cacheMutex.RLock()
 	defer c.cacheMutex.RUnlock()
 
-	if fs, ok := c.volumeCache[volumeName]; ok {
-		klog.V(4).InfoS("FindFileSystemByVolumeName: found in cache", "volumeName", volumeName)
-		return fs, nil
+	fsId, ok := c.fsIdCache[volumeName]
+	if ok {
+		klog.V(4).InfoS("GetFileSystemIdByVolumeName: cache hit", "volumeName", volumeName, "fileSystemId", fsId)
 	}
-
-	klog.V(4).InfoS("FindFileSystemByVolumeName: not found in cache", "volumeName", volumeName)
-	return nil, ErrNotFound
-}
-
-func (c *cloud) pollFileSystems() {
-	for {
-		newCache := make(map[string]*FileSystem)
-		var nextToken *string
-		const maxResults = 1000
-
-		ctx := context.Background()
-
-		for {
-			input := &fsx.DescribeFileSystemsInput{
-				MaxResults: aws.Int32(maxResults),
-				NextToken:  nextToken,
-			}
-
-			output, err := c.fsx.DescribeFileSystems(ctx, input)
-			if err != nil {
-				klog.ErrorS(err, "pollFileSystems: failed to describe filesystems")
-				break // break inner loop, sleep and retry
-			}
-
-			for _, fs := range output.FileSystems {
-				if fs.Lifecycle != types.FileSystemLifecycleAvailable &&
-					fs.Lifecycle != types.FileSystemLifecycleCreating {
-					continue
-				}
-
-				var volumeName string
-				for _, tag := range fs.Tags {
-					if *tag.Key == VolumeNameTagKey {
-						volumeName = *tag.Value
-						break
-					}
-				}
-
-				if volumeName != "" {
-					mountName := "fsx"
-					if fs.LustreConfiguration.MountName != nil {
-						mountName = *fs.LustreConfiguration.MountName
-					}
-
-					perUnitStorageThroughput := int32(0)
-					if fs.LustreConfiguration.PerUnitStorageThroughput != nil {
-						perUnitStorageThroughput = *fs.LustreConfiguration.PerUnitStorageThroughput
-					}
-
-					newCache[volumeName] = &FileSystem{
-						FileSystemId:             *fs.FileSystemId,
-						CapacityGiB:              *fs.StorageCapacity,
-						DnsName:                  *fs.DNSName,
-						MountName:                mountName,
-						StorageType:              string(fs.StorageType),
-						DeploymentType:           string(fs.LustreConfiguration.DeploymentType),
-						PerUnitStorageThroughput: perUnitStorageThroughput,
-					}
-				}
-			}
-
-			if output.NextToken == nil {
-				break
-			}
-			nextToken = output.NextToken
-		}
-
-		c.cacheMutex.Lock()
-		c.volumeCache = newCache
-		c.cacheMutex.Unlock()
-		klog.V(4).InfoS("pollFileSystems: cache updated", "itemCount", len(newCache))
-
-		time.Sleep(CachePollInterval)
-	}
+	return fsId, ok
 }

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -70,8 +70,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -133,8 +133,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -192,8 +192,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -252,8 +252,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -314,8 +314,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -341,8 +341,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -410,8 +410,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -437,8 +437,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -466,8 +466,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -494,8 +494,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -522,8 +522,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -546,8 +546,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -572,8 +572,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -639,8 +639,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -699,8 +699,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -759,8 +759,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -786,8 +786,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -854,8 +854,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -924,8 +924,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -994,8 +994,8 @@ func TestCreateFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				req := &FileSystemOptions{
@@ -1039,8 +1039,8 @@ func TestDeleteFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				output := &fsx.DeleteFileSystemOutput{}
@@ -1060,8 +1060,8 @@ func TestDeleteFileSystem(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				mockFSx := mocks.NewMockFSx(mockCtl)
 				c := &cloud{
-					fsx:         mockFSx,
-					volumeCache: make(map[string]*FileSystem),
+					fsx:       mockFSx,
+					fsIdCache: make(map[string]string),
 				}
 
 				ctx := context.Background()

--- a/pkg/cloud/fakes.go
+++ b/pkg/cloud/fakes.go
@@ -106,11 +106,10 @@ func (c *FakeCloudProvider) WaitForFileSystemResize(ctx context.Context, fileSys
 	return nil
 }
 
-func (c *FakeCloudProvider) FindFileSystemByVolumeName(ctx context.Context, volumeName string) (*FileSystem, error) {
-	// Check if filesystem exists for this volume name
+func (c *FakeCloudProvider) GetFileSystemIdByVolumeName(volumeName string) (string, bool) {
 	fs, exists := c.fileSystems[volumeName]
 	if exists {
-		return fs, nil
+		return fs.FileSystemId, true
 	}
-	return nil, ErrNotFound
+	return "", false
 }

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -18,7 +18,6 @@ package driver
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -140,24 +139,27 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}
 	defer d.inFlight.Delete(volName)
 
-	existingFS, err := d.cloud.FindFileSystemByVolumeName(ctx, volName)
-	if err != nil && !errors.Is(err, cloud.ErrNotFound) {
-		return nil, status.Errorf(codes.Internal, "Failed to check existing filesystem: %v", err)
-	}
-
+	// Check if we already know the filesystem ID for this volume (from a previous CreateFileSystem call).
+	// If so, skip CreateFileSystem and go straight to polling DescribeFileSystems.
+	// This avoids calling CreateFileSystem with a potentially expired ClientRequestToken on retry.
 	var fs *cloud.FileSystem
-	if existingFS != nil {
-		// Filesystem exists, skip creation
-		klog.V(2).InfoS("Found existing filesystem",
-			"volumeName", volName, "fsId", existingFS.FileSystemId)
+	if fsId, ok := d.cloud.GetFileSystemIdByVolumeName(volName); ok {
+		klog.V(2).InfoS("CreateVolume: found cached filesystem ID, skipping CreateFileSystem",
+			"volumeName", volName, "fsId", fsId)
+		existingFS, err := d.cloud.DescribeFileSystem(ctx, fsId)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Failed to describe cached filesystem %s: %v", fsId, err)
+		}
+
+		// Validate that the requested capacity matches the existing filesystem.
+		// This handles the case where a volume with the same name but different size is requested.
 		capRange := req.GetCapacityRange()
 		if capRange != nil && capRange.GetRequiredBytes() > 0 {
-			// Calculate what the requested size WOULD BE after rounding
 			volumeParams := req.GetParameters()
 			deploymentType := volumeParams[volumeParamsDeploymentType]
 			storageType := volumeParams[volumeParamsStorageType]
 
-			var perUnitThroughput int32 = 0
+			var perUnitThroughput int32
 			if val, ok := volumeParams[volumeParamsPerUnitStorageThroughput]; ok {
 				n, err := strconv.ParseInt(val, 10, 32)
 				if err == nil {
@@ -165,18 +167,17 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 				}
 			}
 
-			// Round the requested size using the same logic as creation
 			roundedSizeGiB := util.RoundUpVolumeSize(capRange.GetRequiredBytes(), deploymentType, storageType, perUnitThroughput)
 			roundedSizeInt32, err := util.ConvertToInt32(roundedSizeGiB)
 			if err != nil {
 				return nil, status.Errorf(codes.OutOfRange, "Request storage capacity %d GiB is too large", roundedSizeGiB)
 			}
 
-			// Compare rounded requested size with existing size
 			if existingFS.CapacityGiB != roundedSizeInt32 {
 				return nil, status.Error(codes.AlreadyExists, cloud.ErrFsExistsDiffSize.Error())
 			}
 		}
+
 		fs = existingFS
 	} else {
 		// No existing filesystem, create new one
@@ -308,6 +309,7 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		}
 		fsOptions.ExtraTags = tagArray
 
+		var err error
 		fs, err = d.cloud.CreateFileSystem(ctx, volName, fsOptions)
 		if err != nil {
 			switch err {
@@ -319,7 +321,7 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		}
 	}
 
-	err = d.cloud.WaitForFileSystemAvailable(ctx, fs.FileSystemId)
+	err := d.cloud.WaitForFileSystemAvailable(ctx, fs.FileSystemId)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Filesystem is not ready: %v", err)
 	}

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -94,7 +94,7 @@ func TestCreateVolume(t *testing.T) {
 					DnsName:      dnsName,
 					MountName:    mountName,
 				}
-				mockCloud.EXPECT().FindFileSystemByVolumeName(gomock.Eq(ctx), gomock.Eq(volumeName)).Return(nil, cloud.ErrNotFound)
+				mockCloud.EXPECT().GetFileSystemIdByVolumeName(gomock.Eq(volumeName)).Return("", false)
 				mockCloud.EXPECT().CreateFileSystem(gomock.Eq(ctx), gomock.Eq(volumeName), gomock.Any()).Return(fs, nil)
 				mockCloud.EXPECT().WaitForFileSystemAvailable(gomock.Eq(ctx), gomock.Eq(fileSystemId)).Return(nil)
 
@@ -171,7 +171,7 @@ func TestCreateVolume(t *testing.T) {
 					DnsName:      dnsName,
 					MountName:    mountName,
 				}
-				mockCloud.EXPECT().FindFileSystemByVolumeName(gomock.Eq(ctx), gomock.Eq(volumeName)).Return(nil, cloud.ErrNotFound)
+				mockCloud.EXPECT().GetFileSystemIdByVolumeName(gomock.Eq(volumeName)).Return("", false)
 				mockCloud.EXPECT().CreateFileSystem(gomock.Eq(ctx), gomock.Eq(volumeName), gomock.Any()).Return(fs, nil)
 				mockCloud.EXPECT().WaitForFileSystemAvailable(gomock.Eq(ctx), gomock.Eq(fileSystemId)).Return(nil)
 
@@ -253,7 +253,7 @@ func TestCreateVolume(t *testing.T) {
 					DnsName:      dnsName,
 					MountName:    mountName,
 				}
-				mockCloud.EXPECT().FindFileSystemByVolumeName(gomock.Eq(ctx), gomock.Eq(volumeName)).Return(nil, cloud.ErrNotFound)
+				mockCloud.EXPECT().GetFileSystemIdByVolumeName(gomock.Eq(volumeName)).Return("", false)
 				mockCloud.EXPECT().CreateFileSystem(gomock.Eq(ctx), gomock.Eq(volumeName), gomock.Any()).Return(fs, nil)
 				mockCloud.EXPECT().WaitForFileSystemAvailable(gomock.Eq(ctx), gomock.Eq(fileSystemId)).Return(nil)
 
@@ -338,7 +338,7 @@ func TestCreateVolume(t *testing.T) {
 					DnsName:      dnsName,
 					MountName:    mountName,
 				}
-				mockCloud.EXPECT().FindFileSystemByVolumeName(gomock.Eq(ctx), gomock.Eq(volumeName)).Return(nil, cloud.ErrNotFound)
+				mockCloud.EXPECT().GetFileSystemIdByVolumeName(gomock.Eq(volumeName)).Return("", false)
 				mockCloud.EXPECT().CreateFileSystem(gomock.Eq(ctx), gomock.Eq(volumeName), gomock.Any()).Return(fs, nil)
 				mockCloud.EXPECT().WaitForFileSystemAvailable(gomock.Eq(ctx), gomock.Eq(fileSystemId)).Return(nil)
 
@@ -411,7 +411,7 @@ func TestCreateVolume(t *testing.T) {
 					DnsName:      dnsName,
 					MountName:    mountName,
 				}
-				mockCloud.EXPECT().FindFileSystemByVolumeName(gomock.Eq(ctx), gomock.Eq(volumeName)).Return(nil, cloud.ErrNotFound)
+				mockCloud.EXPECT().GetFileSystemIdByVolumeName(gomock.Eq(volumeName)).Return("", false)
 				mockCloud.EXPECT().CreateFileSystem(gomock.Eq(ctx), gomock.Eq(volumeName), gomock.Any()).Return(fs, nil)
 				mockCloud.EXPECT().WaitForFileSystemAvailable(gomock.Eq(ctx), gomock.Eq(fileSystemId)).Return(nil)
 
@@ -454,6 +454,115 @@ func TestCreateVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "success: retry uses cached filesystem ID (idempotency)",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := controllerService{
+					cloud:         mockCloud,
+					inFlight:      internal.NewInFlight(),
+					driverOptions: &DriverOptions{},
+				}
+
+				req := &csi.CreateVolumeRequest{
+					Name: volumeName,
+					VolumeCapabilities: []*csi.VolumeCapability{
+						stdVolCap,
+					},
+					Parameters: map[string]string{
+						volumeParamsSubnetId:         subnetId,
+						volumeParamsSecurityGroupIds: securityGroupIds,
+					},
+				}
+
+				ctx := context.Background()
+				fs := &cloud.FileSystem{
+					FileSystemId: fileSystemId,
+					CapacityGiB:  volumeSizeGiB,
+					DnsName:      dnsName,
+					MountName:    mountName,
+				}
+
+				// Simulate retry: cache already has the filesystem ID from a previous call
+				mockCloud.EXPECT().GetFileSystemIdByVolumeName(gomock.Eq(volumeName)).Return(fileSystemId, true)
+				mockCloud.EXPECT().DescribeFileSystem(gomock.Eq(ctx), gomock.Eq(fileSystemId)).Return(fs, nil)
+				// CreateFileSystem must NOT be called on retry
+				mockCloud.EXPECT().CreateFileSystem(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				mockCloud.EXPECT().WaitForFileSystemAvailable(gomock.Eq(ctx), gomock.Eq(fileSystemId)).Return(nil)
+
+				resp, err := driver.CreateVolume(ctx, req)
+				if err != nil {
+					t.Fatalf("CreateVolume is failed: %v", err)
+				}
+
+				if resp.Volume == nil {
+					t.Fatal("resp.Volume is nil")
+				}
+
+				if resp.Volume.VolumeId != fileSystemId {
+					t.Fatalf("VolumeId mismatches. actual: %v expected: %v", resp.Volume.VolumeId, fileSystemId)
+				}
+
+				dnsname, exists := resp.Volume.VolumeContext[volumeContextDnsName]
+				if !exists {
+					t.Fatal("dnsname is missing")
+				}
+
+				if dnsname != dnsName {
+					t.Fatalf("dnsname mismatches. actual: %v expected: %v", dnsname, dnsName)
+				}
+
+				mountname, exists := resp.Volume.VolumeContext[volumeContextMountName]
+				if !exists {
+					t.Fatal("mountname is missing")
+				}
+
+				if mountname != mountName {
+					t.Fatalf("mountname mismatches. actual: %v expected: %v", mountname, mountName)
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
+			name: "fail: retry cached filesystem describe fails",
+			testFunc: func(t *testing.T) {
+				mockCtl := gomock.NewController(t)
+				mockCloud := mocks.NewMockCloud(mockCtl)
+
+				driver := controllerService{
+					cloud:         mockCloud,
+					inFlight:      internal.NewInFlight(),
+					driverOptions: &DriverOptions{},
+				}
+
+				req := &csi.CreateVolumeRequest{
+					Name: volumeName,
+					VolumeCapabilities: []*csi.VolumeCapability{
+						stdVolCap,
+					},
+					Parameters: map[string]string{
+						volumeParamsSubnetId:         subnetId,
+						volumeParamsSecurityGroupIds: securityGroupIds,
+					},
+				}
+
+				ctx := context.Background()
+
+				// Cache hit but DescribeFileSystem fails (e.g., FS was deleted)
+				mockCloud.EXPECT().GetFileSystemIdByVolumeName(gomock.Eq(volumeName)).Return(fileSystemId, true)
+				mockCloud.EXPECT().DescribeFileSystem(gomock.Eq(ctx), gomock.Eq(fileSystemId)).Return(nil, cloud.ErrNotFound)
+
+				_, err := driver.CreateVolume(ctx, req)
+				if err == nil {
+					t.Fatal("CreateVolume should have failed")
+				}
+
+				mockCtl.Finish()
+			},
+		},
+		{
 			name: "fail: invalid extraTags",
 			testFunc: func(t *testing.T) {
 				mockCtl := gomock.NewController(t)
@@ -478,7 +587,7 @@ func TestCreateVolume(t *testing.T) {
 				}
 
 				ctx := context.Background()
-				mockCloud.EXPECT().FindFileSystemByVolumeName(gomock.Eq(ctx), gomock.Eq(volumeName)).Return(nil, cloud.ErrNotFound)
+				mockCloud.EXPECT().GetFileSystemIdByVolumeName(gomock.Eq(volumeName)).Return("", false)
 				_, err := driver.CreateVolume(ctx, req)
 				if err == nil {
 					t.Fatal("CreateVolume is not failed")
@@ -603,7 +712,7 @@ func TestCreateVolume(t *testing.T) {
 				}
 
 				ctx := context.Background()
-				mockCloud.EXPECT().FindFileSystemByVolumeName(gomock.Eq(ctx), gomock.Eq(volumeName)).Return(nil, cloud.ErrNotFound)
+				mockCloud.EXPECT().GetFileSystemIdByVolumeName(gomock.Eq(volumeName)).Return("", false)
 				mockCloud.EXPECT().CreateFileSystem(gomock.Eq(ctx), gomock.Eq(volumeName), gomock.Any()).Return(nil, cloud.ErrFsExistsDiffSize)
 
 				_, err := driver.CreateVolume(ctx, req)

--- a/pkg/driver/mocks/mock_cloud.go
+++ b/pkg/driver/mocks/mock_cloud.go
@@ -85,19 +85,19 @@ func (mr *MockCloudMockRecorder) DescribeFileSystem(ctx, fileSystemId any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFileSystem", reflect.TypeOf((*MockCloud)(nil).DescribeFileSystem), ctx, fileSystemId)
 }
 
-// FindFileSystemByVolumeName mocks base method.
-func (m *MockCloud) FindFileSystemByVolumeName(ctx context.Context, volumeName string) (*cloud.FileSystem, error) {
+// GetFileSystemIdByVolumeName mocks base method.
+func (m *MockCloud) GetFileSystemIdByVolumeName(volumeName string) (string, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindFileSystemByVolumeName", ctx, volumeName)
-	ret0, _ := ret[0].(*cloud.FileSystem)
-	ret1, _ := ret[1].(error)
+	ret := m.ctrl.Call(m, "GetFileSystemIdByVolumeName", volumeName)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
-// FindFileSystemByVolumeName indicates an expected call of FindFileSystemByVolumeName.
-func (mr *MockCloudMockRecorder) FindFileSystemByVolumeName(ctx, volumeName any) *gomock.Call {
+// GetFileSystemIdByVolumeName indicates an expected call of GetFileSystemIdByVolumeName.
+func (mr *MockCloudMockRecorder) GetFileSystemIdByVolumeName(volumeName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindFileSystemByVolumeName", reflect.TypeOf((*MockCloud)(nil).FindFileSystemByVolumeName), ctx, volumeName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileSystemIdByVolumeName", reflect.TypeOf((*MockCloud)(nil).GetFileSystemIdByVolumeName), volumeName)
 }
 
 // ResizeFileSystem mocks base method.


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix

**What is this PR about? / Why do we need it?**
We can reduce the number of API calls needed to populate the in-memory volume cache by having a FS cache. 

**What testing is done?** 
```
I0707 21:24:53.299402       1 controller.go:120] "CreateVolume: called" args="name:\"pvc-de547017-3d8b-4567-a3c4-8a2c26b0047f\"  capacity_range:{required_bytes:1288490188800}  volume_capabilities:{mount:{}  access_mode:{mode:MULTI_NODE_MULTI_WRITER}}  parameters:{key:\"csi.storage.k8s.io/pv/name\"  value:\"pvc-de547017-3d8b-4567-a3c4-8a2c26b0047f\"}  parameters:{key:\"csi.storage.k8s.io/pvc/name\"  value:\"test-idempotency\"}  parameters:{key:\"csi.storage.k8s.io/pvc/namespace\"  value:\"default\"}  parameters:{key:\"deploymentType\"  value:\"SCRATCH_2\"}  parameters:{key:\"securityGroupIds\"  value:\"sg-0b2278d56973e7658\"}  parameters:{key:\"subnetId\"  value:\"subnet-0d3e6d835c32210de\"}"
I0707 21:24:54.455940       1 cloud.go:283] "CreateFileSystem: cached filesystem ID" volumeName="pvc-de547017-3d8b-4567-a3c4-8a2c26b0047f" fileSystemId="fs-01440f8d72faa3bfa"
I0707 21:25:25.052960       1 cloud.go:375] "WaitForFileSystemAvailable" filesystem="fs-01440f8d72faa3bfa" status="CREATING"
I0707 21:25:54.737242       1 cloud.go:375] "WaitForFileSystemAvailable" filesystem="fs-01440f8d72faa3bfa" status="CREATING"
I0707 21:26:24.787188       1 cloud.go:375] "WaitForFileSystemAvailable" filesystem="fs-01440f8d72faa3bfa" status="CREATING"
I0707 21:26:54.938189       1 cloud.go:375] "WaitForFileSystemAvailable" filesystem="fs-01440f8d72faa3bfa" status="CREATING"
I0707 21:27:25.286816       1 cloud.go:375] "WaitForFileSystemAvailable" filesystem="fs-01440f8d72faa3bfa" status="CREATING"
I0707 21:27:54.709627       1 cloud.go:375] "WaitForFileSystemAvailable" filesystem="fs-01440f8d72faa3bfa" status="CREATING"
I0707 21:28:24.728749       1 cloud.go:375] "WaitForFileSystemAvailable" filesystem="fs-01440f8d72faa3bfa" status="CREATING"
I0707 21:28:54.817791       1 cloud.go:375] "WaitForFileSystemAvailable" filesystem="fs-01440f8d72faa3bfa" status="CREATING"
I0707 21:29:24.925148       1 cloud.go:375] "WaitForFileSystemAvailable" filesystem="fs-01440f8d72faa3bfa" status="CREATING"
I0707 21:29:54.300466       1 controller.go:120] "CreateVolume: called" args="name:\"pvc-de547017-3d8b-4567-a3c4-8a2c26b0047f\"  capacity_range:{required_bytes:1288490188800}  volume_capabilities:{mount:{}  access_mode:{mode:MULTI_NODE_MULTI_WRITER}}  parameters:{key:\"csi.storage.k8s.io/pv/name\"  value:\"pvc-de547017-3d8b-4567-a3c4-8a2c26b0047f\"}  parameters:{key:\"csi.storage.k8s.io/pvc/name\"  value:\"test-idempotency\"}  parameters:{key:\"csi.storage.k8s.io/pvc/namespace\"  value:\"default\"}  parameters:{key:\"deploymentType\"  value:\"SCRATCH_2\"}  parameters:{key:\"securityGroupIds\"  value:\"sg-0cc85cf7574986971,sg-0b2278d56973e7658\"}  parameters:{key:\"subnetId\"  value:\"subnet-0d3e6d835c32210de\"}"
E0707 21:29:54.300704       1 driver.go:105] "GRPC error" err="rpc error: code = Aborted desc = Create volume request for pvc-de547017-3d8b-4567-a3c4-8a2c26b0047f is already in progress"
I0707 21:29:54.456398       1 inflight.go:73] "Volume operation finished" key="pvc-de547017-3d8b-4567-a3c4-8a2c26b0047f"
E0707 21:29:54.456419       1 driver.go:105] "GRPC error" err="rpc error: code = Internal desc = Filesystem is not ready: operation error FSx: DescribeFileSystems, context canceled"
I0707 21:29:56.302212       1 controller.go:120] "CreateVolume: called" args="name:\"pvc-de547017-3d8b-4567-a3c4-8a2c26b0047f\"  capacity_range:{required_bytes:1288490188800}  volume_capabilities:{mount:{}  access_mode:{mode:MULTI_NODE_MULTI_WRITER}}  parameters:{key:\"csi.storage.k8s.io/pv/name\"  value:\"pvc-de547017-3d8b-4567-a3c4-8a2c26b0047f\"}  parameters:{key:\"csi.storage.k8s.io/pvc/name\"  value:\"test-idempotency\"}  parameters:{key:\"csi.storage.k8s.io/pvc/namespace\"  value:\"default\"}  parameters:{key:\"deploymentType\"  value:\"SCRATCH_2\"}  parameters:{key:\"securityGroupIds\"  value:\"sg-0cc85cf7574986971,sg-0b2278d56973e7658\"}  parameters:{key:\"subnetId\"  value:\"subnet-0d3e6d835c32210de\"}"
I0707 21:29:56.302336       1 cloud.go:479] "GetFileSystemIdByVolumeName: cache hit" volumeName="pvc-de547017-3d8b-4567-a3c4-8a2c26b0047f" fileSystemId="fs-01440f8d72faa3bfa"
I0707 21:29:56.302358       1 controller.go:147] "CreateVolume: found cached filesystem ID, skipping CreateFileSystem" volumeName="pvc-de547017-3d8b-4567-a3c4-8a2c26b0047f" fsId="fs-01440f8d72faa3bfa"
I0707 21:30:27.307049       1 cloud.go:375] "WaitForFileSystemAvailable" filesystem="fs-01440f8d72faa3bfa" status="CREATING"
I0707 21:30:57.287146       1 cloud.go:375] "WaitForFileSystemAvailable" filesystem="fs-01440f8d72faa3bfa" status="CREATING"
I0707 21:31:27.358202       1 cloud.go:375] "WaitForFileSystemAvailable" filesystem="fs-01440f8d72faa3bfa" status="CREATING"
I0707 21:31:57.208759       1 cloud.go:375] "WaitForFileSystemAvailable" filesystem="fs-01440f8d72faa3bfa" status="CREATING"
I0707 21:32:27.337756       1 cloud.go:375] "WaitForFileSystemAvailable" filesystem="fs-01440f8d72faa3bfa" status="AVAILABLE"
I0707 21:32:27.337789       1 inflight.go:73] "Volume operation finished" key="pvc-de547017-3d8b-4567-a3c4-8a2c26b0047f"
```
